### PR TITLE
Connect with homepage

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,4 @@
+REACT_APP_SERVICE_URL=https://yorkie.dev
 REACT_APP_ADMIN_ADDR=http://localhost:9090
 REACT_APP_API_ADDR=http://localhost:8080
 REACT_APP_JS_SDK_URL=https://cdnjs.cloudflare.com/ajax/libs/yorkie-js-sdk/0.2.16/yorkie-js-sdk.js

--- a/.env.production
+++ b/.env.production
@@ -1,3 +1,4 @@
+REACT_APP_SERVICE_URL=https://yorkie.dev
 REACT_APP_SITE_URL=https://yorkie.dev/dashboard/
 REACT_APP_ADMIN_ADDR=https://admin.yorkie.dev
 REACT_APP_API_ADDR=https://api.yorkie.dev

--- a/package.json
+++ b/package.json
@@ -100,7 +100,8 @@
             "mailto",
             "jsx",
             "svg",
-            "gnb"
+            "gnb",
+            "resize"
           ],
           "skipIfMatch": [
             "TODO\\(.+\\):",

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -15,6 +15,7 @@
  */
 
 import React, { ReactNode } from 'react';
+import { Link } from 'react-router-dom';
 
 export function Breadcrumb({ children }: { children: ReactNode }) {
   return <div className="breadcrumb team_view">{children}</div>;
@@ -24,16 +25,40 @@ function Inner({ children }: { children: ReactNode }) {
   return <div className="breadcrumb_inner">{children}</div>;
 }
 
-const Item = React.forwardRef<
-  HTMLButtonElement,
-  { children: ReactNode; onClick?: React.MouseEventHandler<HTMLButtonElement> }
->(({ children, onClick }, ref) => {
-  return (
-    <button type="button" ref={ref} className="breadcrumb_item" onClick={onClick}>
-      {children}
-    </button>
-  );
-});
+const Item = React.forwardRef(
+  (
+    {
+      as = 'button',
+      href = '',
+      children,
+      ...restProps
+    }: {
+      as?: 'button' | 'a' | 'link';
+      href?: string;
+      children?: ReactNode;
+    } & React.AnchorHTMLAttributes<HTMLAnchorElement> &
+      React.ButtonHTMLAttributes<HTMLButtonElement>,
+    ref,
+  ) => {
+    if (as === 'link') {
+      return (
+        <Link to={href} ref={ref as React.ForwardedRef<HTMLAnchorElement>} className="breadcrumb_item" {...restProps}>
+          {children}
+        </Link>
+      );
+    }
+    return (
+      <button
+        type="button"
+        ref={ref as React.ForwardedRef<HTMLButtonElement>}
+        className="breadcrumb_item"
+        {...restProps}
+      >
+        {children}
+      </button>
+    );
+  },
+);
 Item.displayName = 'Breadcrumb.Item';
 
 function Thumb({ src }: { src: string }) {

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -64,7 +64,7 @@ function Item({
       style={{ display: 'block' }}
     >
       {as === 'a' && (
-        <a href={href} className="dropdown_menu" target="_blank" rel="noreferrer">
+        <a href={href} className="dropdown_menu">
           {children}
         </a>
       )}

--- a/src/features/users/AccountDropdown.tsx
+++ b/src/features/users/AccountDropdown.tsx
@@ -14,25 +14,33 @@
  * limitations under the License.
  */
 
-import React, { useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
-
+import React, { useCallback, useState, useEffect } from 'react';
 import { useAppSelector, useAppDispatch } from 'app/hooks';
 import { selectUsers, logoutUser } from './usersSlice';
 import { Popover, Dropdown } from 'components';
 
 export function AccountDropdown() {
   const { username } = useAppSelector(selectUsers);
+  const [opened, setOpened] = useState(false);
 
-  const navigate = useNavigate();
   const dispatch = useAppDispatch();
   const logout = useCallback(() => {
     dispatch(logoutUser());
-    navigate('/login');
-  }, [dispatch, navigate]);
+  }, [dispatch]);
+
+  useEffect(() => {
+    const handleResize = () => {
+      const PC_WIDTH = 1024;
+      if (window.innerWidth < PC_WIDTH) {
+        setOpened(false);
+      }
+    };
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
 
   return (
-    <Popover>
+    <Popover opened={opened} onChange={setOpened}>
       <Popover.Target>
         <button className="util_menu user_profile">
           <span className="blind">User profile</span>

--- a/src/features/users/MobileGnbDropdown.tsx
+++ b/src/features/users/MobileGnbDropdown.tsx
@@ -15,7 +15,6 @@
  */
 
 import React, { useCallback, useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 import classNames from 'classnames';
 import { useAppSelector, useAppDispatch } from 'app/hooks';
 import { selectUsers, logoutUser } from './usersSlice';
@@ -25,28 +24,26 @@ export function MobileGnbDropdown() {
   const { username } = useAppSelector(selectUsers);
   const [opened, setOpened] = useState(false);
 
-  const navigate = useNavigate();
   const dispatch = useAppDispatch();
   const logout = useCallback(() => {
     dispatch(logoutUser());
-    navigate('/login');
-  }, [dispatch, navigate]);
+  }, [dispatch]);
 
   useEffect(() => {
-    return () => {
-      setOpened(false);
+    const handleResize = () => {
+      const PC_WIDTH = 1024;
+      if (window.innerWidth >= PC_WIDTH) {
+        setOpened(false);
+      }
     };
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
   }, []);
 
   return (
     <Popover opened={opened} onChange={setOpened}>
       <Popover.Target>
-        <button
-          className="btn_menu"
-          onClick={() => {
-            setOpened((opened) => !opened);
-          }}
-        >
+        <button className="btn_menu">
           <span className="blind">Open menu</span>
           <Icon type="gnbMenu" className={classNames('icon_menu', { is_active: !opened })} />
           <Icon type="close" className={classNames('icon_close', { is_active: opened })} />
@@ -55,11 +52,17 @@ export function MobileGnbDropdown() {
       <Popover.Dropdown>
         <Dropdown className="util_list_mo">
           <Dropdown.List>
+            <Dropdown.Item as="a" href={`${process.env.REACT_APP_SERVICE_URL}`}>
+              <Dropdown.Text>Home</Dropdown.Text>
+            </Dropdown.Item>
+            <Dropdown.Item as="link" href="/projects">
+              <Dropdown.Text>Dashboard</Dropdown.Text>
+            </Dropdown.Item>
+            <Dropdown.Item as="a" href={`${process.env.REACT_APP_SERVICE_URL}/docs`}>
+              <Dropdown.Text>Documentation</Dropdown.Text>
+            </Dropdown.Item>
             <Dropdown.Item as="link" href="/community">
               <Dropdown.Text>Feedback</Dropdown.Text>
-            </Dropdown.Item>
-            <Dropdown.Item as="a" href="https://yorkie.dev/docs">
-              <Dropdown.Text>Docs</Dropdown.Text>
             </Dropdown.Item>
           </Dropdown.List>
           <Dropdown.List>

--- a/src/features/users/usersSlice.ts
+++ b/src/features/users/usersSlice.ts
@@ -32,6 +32,9 @@ export interface UsersState {
       message: string;
     } | null;
   };
+  logout: {
+    isSuccess: boolean;
+  };
   signup: {
     isSuccess: boolean;
     status: 'idle' | 'loading' | 'failed';
@@ -41,14 +44,13 @@ export interface UsersState {
     theme: {
       useSystem: boolean;
       darkMode: boolean;
-    }
+    };
     use24HourClock: boolean;
   };
 }
 
 function isDarkMode(): boolean {
-  return window.matchMedia &&
-    window.matchMedia('(prefers-color-scheme: dark)').matches;
+  return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
 }
 
 type ErrorDetails = {
@@ -80,6 +82,9 @@ const initialState: UsersState = {
     status: 'idle',
     error: null,
   },
+  logout: {
+    isSuccess: false,
+  },
   signup: {
     isSuccess: false,
     status: 'idle',
@@ -88,7 +93,8 @@ const initialState: UsersState = {
   preferences: {
     theme: {
       useSystem: localStorage.getItem('theme') === 'system',
-      darkMode: (localStorage.getItem('theme') === 'system' && isDarkMode()) || localStorage.getItem('theme') === 'dark',
+      darkMode:
+        (localStorage.getItem('theme') === 'system' && isDarkMode()) || localStorage.getItem('theme') === 'dark',
     },
     use24HourClock: localStorage.getItem('clock') === '24',
   },
@@ -134,6 +140,7 @@ export const usersSlice = createSlice({
       state.login.status = 'idle';
       state.login.isSuccess = false;
       state.login.error = null;
+      state.logout.isSuccess = true;
     },
     setIsValidToken: (state, action) => {
       state.isValidToken = action.payload;

--- a/src/pages/Footer.tsx
+++ b/src/pages/Footer.tsx
@@ -20,7 +20,9 @@ import { Icon } from 'components';
 export function Footer() {
   return (
     <footer className="footer">
-      <Icon type="LogoHorizontalGray" fill />
+      <a href={`${process.env.REACT_APP_SERVICE_URL}`}>
+        <Icon type="LogoHorizontalGray" fill />
+      </a>
     </footer>
   );
 }

--- a/src/pages/Header.tsx
+++ b/src/pages/Header.tsx
@@ -31,22 +31,29 @@ export function Header({ className }: { className?: string }) {
       <div className="header_inner">
         <Breadcrumb>
           <h1 className="logo">
-            <Link to={token && isValidToken ? '/projects' : '/'} className="logo_menu">
+            <a href={`${process.env.REACT_APP_SERVICE_URL}`} className="logo_menu">
               <Icon type="logoNoText" fill />
-            </Link>
+            </a>
             <span className="blind">Yorkie</span>
           </h1>
           {token && isValidToken && (
-            <Breadcrumb.Inner>
-              <ProjectDropdown />
-            </Breadcrumb.Inner>
+            <>
+              <Breadcrumb.Inner>
+                <Breadcrumb.Item as="link" href="/projects">
+                  <Breadcrumb.Text>Dashboard</Breadcrumb.Text>
+                </Breadcrumb.Item>
+              </Breadcrumb.Inner>
+              <Breadcrumb.Inner>
+                <ProjectDropdown />
+              </Breadcrumb.Inner>
+            </>
           )}
         </Breadcrumb>
         {token && isValidToken && (
           <nav className="util_box">
             <ul className="util_list">
               <li className="util_item">
-                <a href="https://yorkie.dev/docs" target="_blank" rel="noreferrer" className="util_menu">
+                <a href={`${process.env.REACT_APP_SERVICE_URL}/docs`} className="util_menu">
                   Docs
                 </a>
               </li>

--- a/src/pages/PrivateRoute.tsx
+++ b/src/pages/PrivateRoute.tsx
@@ -17,21 +17,22 @@
 import React, { useEffect } from 'react';
 import { Outlet, useNavigate, useLocation } from 'react-router-dom';
 
-import { useAppSelector } from 'app/hooks';
+import { useAppSelector, useAppDispatch } from 'app/hooks';
 import { selectUsers } from 'features/users/usersSlice';
 
 export function PrivateRoute() {
   const navigate = useNavigate();
+  const dispatch = useAppDispatch();
   const location = useLocation();
-  const { token, isValidToken } = useAppSelector(selectUsers);
+  const { token, isValidToken, logout } = useAppSelector(selectUsers);
 
   useEffect(() => {
-    if (!token || !isValidToken) {
+    if (logout.isSuccess) {
+      window.location.href = `${process.env.REACT_APP_SERVICE_URL}`;
+    } else if (!token || !isValidToken) {
       navigate('/login', { state: { from: location.pathname } });
     }
-  }, [token, navigate, location, isValidToken]);
+  }, [token, navigate, location, isValidToken, logout, dispatch]);
 
-  return (
-    <Outlet />
-  );
+  return <Outlet />;
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

- Navigate to the homepage when the user signs out. 
- There are two versions for displaying the "home" and "dashboard" in the mobile navigation. 
  - This PR applied version 1. 
  - Version 2 is similar to the mobile header of the homepage, but we need to consider the UI when the project name becomes longer or the team is added.
![image](https://user-images.githubusercontent.com/81357083/208396367-632c9666-1dc0-452d-93ab-d15785693cbb.png)



#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
