### PR TITLE
Moved auth token from localStorage to cookie

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -39,6 +39,23 @@ import * as converter from './converter';
 
 export * from './types';
 
+// setCookie sets new cookie key-value pair.
+export function setCookie(key: string, value: string) {
+  document.cookie = `${key}=${value}`;
+}
+
+// getCookie returns corresponding value to key parameter.
+export function getCookie(key: string): string {
+  if (document.cookie === '') {
+    return '';
+  }
+  const cookies = document.cookie.split(';').map(pair =>
+    pair.split('=').map(value => value.trim())
+  );
+  const cookie = cookies.find(cookie => cookie[0] === key);
+  return cookie ? cookie[1] : '';
+}
+
 // TODO(hackerwins): Consider combining these two interceptors into one.
 const unaryInterceptor = new DefaultUnaryInterceptor();
 const streamInterceptor = new DefaultStreamInterceptor();

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -39,23 +39,6 @@ import * as converter from './converter';
 
 export * from './types';
 
-// setCookie sets new cookie key-value pair.
-export function setCookie(key: string, value: string) {
-  document.cookie = `${key}=${value}`;
-}
-
-// getCookie returns corresponding value to key parameter.
-export function getCookie(key: string): string {
-  if (document.cookie === '') {
-    return '';
-  }
-  const cookies = document.cookie.split(';').map(pair =>
-    pair.split('=').map(value => value.trim())
-  );
-  const cookie = cookies.find(cookie => cookie[0] === key);
-  return cookie ? cookie[1] : '';
-}
-
 // TODO(hackerwins): Consider combining these two interceptors into one.
 const unaryInterceptor = new DefaultUnaryInterceptor();
 const streamInterceptor = new DefaultStreamInterceptor();

--- a/src/features/users/usersSlice.ts
+++ b/src/features/users/usersSlice.ts
@@ -74,7 +74,7 @@ type JWTPayload = {
 };
 
 const initialState: UsersState = {
-  token: localStorage.getItem('token') || '',
+  token: api.getCookie('token'),
   isValidToken: false,
   username: '',
   login: {
@@ -114,7 +114,7 @@ export const loginUser = createAsyncThunk<string, LoginFields>('users/login', as
   const token = await api.logIn(username, password);
   // TODO(hackerwins): For security, we need to change the token to be stored in the cookie.
   // For more information, see https://github.com/yorkie-team/dashboard/issues/42.
-  localStorage.setItem('token', token);
+  api.setCookie('token', token);
   return token;
 });
 
@@ -134,7 +134,7 @@ export const usersSlice = createSlice({
   initialState,
   reducers: {
     logoutUser: (state) => {
-      localStorage.removeItem('token');
+      api.setCookie('token', '');
       api.setToken('');
       state.token = '';
       state.isValidToken = false;

--- a/src/features/users/usersSlice.ts
+++ b/src/features/users/usersSlice.ts
@@ -19,6 +19,7 @@ import * as api from 'api';
 import { User, RPCStatusCode } from 'api/types';
 import { RootState } from 'app/store';
 import jwt_decode from 'jwt-decode';
+import * as util from 'utils';
 
 export interface UsersState {
   token: string;
@@ -74,7 +75,7 @@ type JWTPayload = {
 };
 
 const initialState: UsersState = {
-  token: api.getCookie('token'),
+  token: util.getCookie('token') || '',
   isValidToken: false,
   username: '',
   login: {
@@ -114,7 +115,7 @@ export const loginUser = createAsyncThunk<string, LoginFields>('users/login', as
   const token = await api.logIn(username, password);
   // TODO(hackerwins): For security, we need to change the token to be stored in the cookie.
   // For more information, see https://github.com/yorkie-team/dashboard/issues/42.
-  api.setCookie('token', token);
+  util.setCookie('token', token, window.location.hostname);
   return token;
 });
 
@@ -134,7 +135,7 @@ export const usersSlice = createSlice({
   initialState,
   reducers: {
     logoutUser: (state) => {
-      api.setCookie('token', '');
+      util.deleteCookie('token', window.location.hostname);
       api.setToken('');
       state.token = '';
       state.isValidToken = false;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,25 @@
 export * from './create-safe-context';
 export * from './is-element';
 export * from './merge-refs';
+
+// setCookie sets new cookie key-value pair.
+export function setCookie(key: string, value: string, domain: string, path: string = '/') {
+  document.cookie = `${key}=${value};domain=${domain};path=${path}`;
+}
+
+// getCookie returns corresponding cookie value to key parameter.
+export function getCookie(key: string): string | undefined {
+  if (document.cookie === '') {
+    return undefined;
+  }
+  const cookies = document.cookie.split(';').map(pair =>
+    pair.split('=').map(value => value.trim())
+  );
+  const cookie = cookies.find(cookie => cookie[0] === key);
+  return cookie ? cookie[1] : undefined;
+}
+
+// deleteCookie deletes corresponding cookie key-value pair.
+export function deleteCookie(key: string, domain: string, path: string = '/') {
+  document.cookie = `${key}=;domain=${domain};path=${path};max-age=0`;
+}


### PR DESCRIPTION
#### What this PR does / why we need it?
- Login auth token was in localStorage until now.
- Since localStorage is vulnerable to XSS attacks, auth token should be stored in a cookie.

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes #42

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
