### PR TITLE
Add ClientDeactivateThreshold Update Field in Project Settings

### DIFF
--- a/src/api/converter.ts
+++ b/src/api/converter.ts
@@ -45,6 +45,7 @@ export function fromProject(pbProject: PbProject): Project {
     createdAt: fromTimestamp(pbProject.getCreatedAt()!),
     authWebhookURL: pbProject.getAuthWebhookUrl(),
     authWebhookMethods: pbProject.getAuthWebhookMethodsList() as Array<AuthWebhookMethod>,
+    clientDeactivateThreshold: pbProject.getClientDeactivateThreshold(),
   };
 }
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -113,6 +113,10 @@ export async function updateProject(id: string, fields: UpdatableProjectFields):
     const authWebhookMethods = new PbProjectFields.AuthWebhookMethods().setMethodsList(fields.authWebhookMethods);
     pbFields.setAuthWebhookMethods(authWebhookMethods);
   }
+  if (fields.clientDeactivateThreshold) {
+    const clientDeactivateThreshold = new PbWrappers.StringValue().setValue(fields.clientDeactivateThreshold);
+    pbFields.setClientDeactivateThreshold(clientDeactivateThreshold);
+  }
 
   req.setFields(pbFields);
   const res = await client.updateProject(req);

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -39,6 +39,7 @@ export type Project = {
   name: string;
   authWebhookURL: string;
   authWebhookMethods: Array<AuthWebhookMethod>;
+  clientDeactivateThreshold: string;
   publicKey: string;
   secretKey: string;
   createdAt: number;
@@ -48,6 +49,7 @@ export type UpdatableProjectFields = {
   name?: string;
   authWebhookURL?: string;
   authWebhookMethods?: Array<AuthWebhookMethod>;
+  clientDeactivateThreshold?: string;
 };
 
 export type AuthWebhookMethod =

--- a/src/api/yorkie/v1/resources.proto
+++ b/src/api/yorkie/v1/resources.proto
@@ -214,8 +214,9 @@ message Project {
   string secret_key = 4;
   string auth_webhook_url = 5;
   repeated string auth_webhook_methods = 6;
-  google.protobuf.Timestamp created_at = 7;
-  google.protobuf.Timestamp updated_at = 8;
+  string client_deactivate_threshold = 7;
+  google.protobuf.Timestamp created_at = 8;
+  google.protobuf.Timestamp updated_at = 9;
 }
 
 message UpdatableProjectFields {
@@ -226,6 +227,7 @@ message UpdatableProjectFields {
   google.protobuf.StringValue name = 1;
   google.protobuf.StringValue auth_webhook_url = 2;
   AuthWebhookMethods auth_webhook_methods = 3;
+  google.protobuf.StringValue client_deactivate_threshold = 4;
 }
 
 message DocumentSummary {

--- a/src/api/yorkie/v1/resources_pb.d.ts
+++ b/src/api/yorkie/v1/resources_pb.d.ts
@@ -985,6 +985,9 @@ export class Project extends jspb.Message {
   clearAuthWebhookMethodsList(): Project;
   addAuthWebhookMethods(value: string, index?: number): Project;
 
+  getClientDeactivateThreshold(): string;
+  setClientDeactivateThreshold(value: string): Project;
+
   getCreatedAt(): google_protobuf_timestamp_pb.Timestamp | undefined;
   setCreatedAt(value?: google_protobuf_timestamp_pb.Timestamp): Project;
   hasCreatedAt(): boolean;
@@ -1011,6 +1014,7 @@ export namespace Project {
     secretKey: string,
     authWebhookUrl: string,
     authWebhookMethodsList: Array<string>,
+    clientDeactivateThreshold: string,
     createdAt?: google_protobuf_timestamp_pb.Timestamp.AsObject,
     updatedAt?: google_protobuf_timestamp_pb.Timestamp.AsObject,
   }
@@ -1032,6 +1036,11 @@ export class UpdatableProjectFields extends jspb.Message {
   hasAuthWebhookMethods(): boolean;
   clearAuthWebhookMethods(): UpdatableProjectFields;
 
+  getClientDeactivateThreshold(): google_protobuf_wrappers_pb.StringValue | undefined;
+  setClientDeactivateThreshold(value?: google_protobuf_wrappers_pb.StringValue): UpdatableProjectFields;
+  hasClientDeactivateThreshold(): boolean;
+  clearClientDeactivateThreshold(): UpdatableProjectFields;
+
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): UpdatableProjectFields.AsObject;
   static toObject(includeInstance: boolean, msg: UpdatableProjectFields): UpdatableProjectFields.AsObject;
@@ -1045,6 +1054,7 @@ export namespace UpdatableProjectFields {
     name?: google_protobuf_wrappers_pb.StringValue.AsObject,
     authWebhookUrl?: google_protobuf_wrappers_pb.StringValue.AsObject,
     authWebhookMethods?: UpdatableProjectFields.AuthWebhookMethods.AsObject,
+    clientDeactivateThreshold?: google_protobuf_wrappers_pb.StringValue.AsObject,
   }
 
   export class AuthWebhookMethods extends jspb.Message {

--- a/src/api/yorkie/v1/resources_pb.js
+++ b/src/api/yorkie/v1/resources_pb.js
@@ -8275,6 +8275,7 @@ proto.yorkie.v1.Project.toObject = function(includeInstance, msg) {
     secretKey: jspb.Message.getFieldWithDefault(msg, 4, ""),
     authWebhookUrl: jspb.Message.getFieldWithDefault(msg, 5, ""),
     authWebhookMethodsList: (f = jspb.Message.getRepeatedField(msg, 6)) == null ? undefined : f,
+    clientDeactivateThreshold: jspb.Message.getFieldWithDefault(msg, 7, ""),
     createdAt: (f = msg.getCreatedAt()) && google_protobuf_timestamp_pb.Timestamp.toObject(includeInstance, f),
     updatedAt: (f = msg.getUpdatedAt()) && google_protobuf_timestamp_pb.Timestamp.toObject(includeInstance, f)
   };
@@ -8338,11 +8339,15 @@ proto.yorkie.v1.Project.deserializeBinaryFromReader = function(msg, reader) {
       msg.addAuthWebhookMethods(value);
       break;
     case 7:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setClientDeactivateThreshold(value);
+      break;
+    case 8:
       var value = new google_protobuf_timestamp_pb.Timestamp;
       reader.readMessage(value,google_protobuf_timestamp_pb.Timestamp.deserializeBinaryFromReader);
       msg.setCreatedAt(value);
       break;
-    case 8:
+    case 9:
       var value = new google_protobuf_timestamp_pb.Timestamp;
       reader.readMessage(value,google_protobuf_timestamp_pb.Timestamp.deserializeBinaryFromReader);
       msg.setUpdatedAt(value);
@@ -8418,10 +8423,17 @@ proto.yorkie.v1.Project.serializeBinaryToWriter = function(message, writer) {
       f
     );
   }
+  f = message.getClientDeactivateThreshold();
+  if (f.length > 0) {
+    writer.writeString(
+      7,
+      f
+    );
+  }
   f = message.getCreatedAt();
   if (f != null) {
     writer.writeMessage(
-      7,
+      8,
       f,
       google_protobuf_timestamp_pb.Timestamp.serializeBinaryToWriter
     );
@@ -8429,7 +8441,7 @@ proto.yorkie.v1.Project.serializeBinaryToWriter = function(message, writer) {
   f = message.getUpdatedAt();
   if (f != null) {
     writer.writeMessage(
-      8,
+      9,
       f,
       google_protobuf_timestamp_pb.Timestamp.serializeBinaryToWriter
     );
@@ -8565,12 +8577,30 @@ proto.yorkie.v1.Project.prototype.clearAuthWebhookMethodsList = function() {
 
 
 /**
- * optional google.protobuf.Timestamp created_at = 7;
+ * optional string client_deactivate_threshold = 7;
+ * @return {string}
+ */
+proto.yorkie.v1.Project.prototype.getClientDeactivateThreshold = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 7, ""));
+};
+
+
+/**
+ * @param {string} value
+ * @return {!proto.yorkie.v1.Project} returns this
+ */
+proto.yorkie.v1.Project.prototype.setClientDeactivateThreshold = function(value) {
+  return jspb.Message.setProto3StringField(this, 7, value);
+};
+
+
+/**
+ * optional google.protobuf.Timestamp created_at = 8;
  * @return {?proto.google.protobuf.Timestamp}
  */
 proto.yorkie.v1.Project.prototype.getCreatedAt = function() {
   return /** @type{?proto.google.protobuf.Timestamp} */ (
-    jspb.Message.getWrapperField(this, google_protobuf_timestamp_pb.Timestamp, 7));
+    jspb.Message.getWrapperField(this, google_protobuf_timestamp_pb.Timestamp, 8));
 };
 
 
@@ -8579,7 +8609,7 @@ proto.yorkie.v1.Project.prototype.getCreatedAt = function() {
  * @return {!proto.yorkie.v1.Project} returns this
 */
 proto.yorkie.v1.Project.prototype.setCreatedAt = function(value) {
-  return jspb.Message.setWrapperField(this, 7, value);
+  return jspb.Message.setWrapperField(this, 8, value);
 };
 
 
@@ -8597,17 +8627,17 @@ proto.yorkie.v1.Project.prototype.clearCreatedAt = function() {
  * @return {boolean}
  */
 proto.yorkie.v1.Project.prototype.hasCreatedAt = function() {
-  return jspb.Message.getField(this, 7) != null;
+  return jspb.Message.getField(this, 8) != null;
 };
 
 
 /**
- * optional google.protobuf.Timestamp updated_at = 8;
+ * optional google.protobuf.Timestamp updated_at = 9;
  * @return {?proto.google.protobuf.Timestamp}
  */
 proto.yorkie.v1.Project.prototype.getUpdatedAt = function() {
   return /** @type{?proto.google.protobuf.Timestamp} */ (
-    jspb.Message.getWrapperField(this, google_protobuf_timestamp_pb.Timestamp, 8));
+    jspb.Message.getWrapperField(this, google_protobuf_timestamp_pb.Timestamp, 9));
 };
 
 
@@ -8616,7 +8646,7 @@ proto.yorkie.v1.Project.prototype.getUpdatedAt = function() {
  * @return {!proto.yorkie.v1.Project} returns this
 */
 proto.yorkie.v1.Project.prototype.setUpdatedAt = function(value) {
-  return jspb.Message.setWrapperField(this, 8, value);
+  return jspb.Message.setWrapperField(this, 9, value);
 };
 
 
@@ -8634,7 +8664,7 @@ proto.yorkie.v1.Project.prototype.clearUpdatedAt = function() {
  * @return {boolean}
  */
 proto.yorkie.v1.Project.prototype.hasUpdatedAt = function() {
-  return jspb.Message.getField(this, 8) != null;
+  return jspb.Message.getField(this, 9) != null;
 };
 
 
@@ -8672,7 +8702,8 @@ proto.yorkie.v1.UpdatableProjectFields.toObject = function(includeInstance, msg)
   var f, obj = {
     name: (f = msg.getName()) && google_protobuf_wrappers_pb.StringValue.toObject(includeInstance, f),
     authWebhookUrl: (f = msg.getAuthWebhookUrl()) && google_protobuf_wrappers_pb.StringValue.toObject(includeInstance, f),
-    authWebhookMethods: (f = msg.getAuthWebhookMethods()) && proto.yorkie.v1.UpdatableProjectFields.AuthWebhookMethods.toObject(includeInstance, f)
+    authWebhookMethods: (f = msg.getAuthWebhookMethods()) && proto.yorkie.v1.UpdatableProjectFields.AuthWebhookMethods.toObject(includeInstance, f),
+    clientDeactivateThreshold: (f = msg.getClientDeactivateThreshold()) && google_protobuf_wrappers_pb.StringValue.toObject(includeInstance, f)
   };
 
   if (includeInstance) {
@@ -8723,6 +8754,11 @@ proto.yorkie.v1.UpdatableProjectFields.deserializeBinaryFromReader = function(ms
       var value = new proto.yorkie.v1.UpdatableProjectFields.AuthWebhookMethods;
       reader.readMessage(value,proto.yorkie.v1.UpdatableProjectFields.AuthWebhookMethods.deserializeBinaryFromReader);
       msg.setAuthWebhookMethods(value);
+      break;
+    case 4:
+      var value = new google_protobuf_wrappers_pb.StringValue;
+      reader.readMessage(value,google_protobuf_wrappers_pb.StringValue.deserializeBinaryFromReader);
+      msg.setClientDeactivateThreshold(value);
       break;
     default:
       reader.skipField();
@@ -8775,6 +8811,14 @@ proto.yorkie.v1.UpdatableProjectFields.serializeBinaryToWriter = function(messag
       3,
       f,
       proto.yorkie.v1.UpdatableProjectFields.AuthWebhookMethods.serializeBinaryToWriter
+    );
+  }
+  f = message.getClientDeactivateThreshold();
+  if (f != null) {
+    writer.writeMessage(
+      4,
+      f,
+      google_protobuf_wrappers_pb.StringValue.serializeBinaryToWriter
     );
   }
 };
@@ -9044,6 +9088,43 @@ proto.yorkie.v1.UpdatableProjectFields.prototype.clearAuthWebhookMethods = funct
  */
 proto.yorkie.v1.UpdatableProjectFields.prototype.hasAuthWebhookMethods = function() {
   return jspb.Message.getField(this, 3) != null;
+};
+
+
+/**
+ * optional google.protobuf.StringValue client_deactivate_threshold = 4;
+ * @return {?proto.google.protobuf.StringValue}
+ */
+proto.yorkie.v1.UpdatableProjectFields.prototype.getClientDeactivateThreshold = function() {
+  return /** @type{?proto.google.protobuf.StringValue} */ (
+    jspb.Message.getWrapperField(this, google_protobuf_wrappers_pb.StringValue, 4));
+};
+
+
+/**
+ * @param {?proto.google.protobuf.StringValue|undefined} value
+ * @return {!proto.yorkie.v1.UpdatableProjectFields} returns this
+*/
+proto.yorkie.v1.UpdatableProjectFields.prototype.setClientDeactivateThreshold = function(value) {
+  return jspb.Message.setWrapperField(this, 4, value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.yorkie.v1.UpdatableProjectFields} returns this
+ */
+proto.yorkie.v1.UpdatableProjectFields.prototype.clearClientDeactivateThreshold = function() {
+  return this.setClientDeactivateThreshold(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.yorkie.v1.UpdatableProjectFields.prototype.hasClientDeactivateThreshold = function() {
+  return jspb.Message.getField(this, 4) != null;
 };
 
 

--- a/src/features/projects/Settings.tsx
+++ b/src/features/projects/Settings.tsx
@@ -54,6 +54,7 @@ export function Settings() {
       name: '',
       authWebhookURL: '',
       authWebhookMethods: [],
+      clientDeactivateThreshold: '',
     },
   });
 
@@ -66,6 +67,10 @@ export function Settings() {
     control,
     name: 'authWebhookMethods',
   });
+  const { field: clientDeactivateThreshold, fieldState: clientDeactivateThresholdState } = useController({ 
+    control, 
+    name: 'clientDeactivateThreshold',
+   });
   const checkFieldState = useCallback(
     (fieldName: keyof UpdatableProjectFields | AuthWebhookMethod, state: 'success' | 'error'): boolean => {
       return updateFieldInfo.target === fieldName && updateFieldInfo.state === state;
@@ -81,6 +86,7 @@ export function Settings() {
       name: project?.name || '',
       authWebhookURL: project?.authWebhookURL || '',
       authWebhookMethods: project?.authWebhookMethods || [],
+      clientDeactivateThreshold: project?.clientDeactivateThreshold || '',
     });
   }, [reset, project]);
 
@@ -103,21 +109,21 @@ export function Settings() {
   );
 
   useEffect(() => {
-    if (updateFieldInfo.state !== 'success' && !nameFieldState.error && !webhookURLFieldState.error) {
+    if (updateFieldInfo.state !== 'success' && !nameFieldState.error && !webhookURLFieldState.error && !clientDeactivateThresholdState.error) {
       setUpdateFieldInfo((info) => ({
         ...info,
         state: null,
       }));
       return;
     }
-    if (nameFieldState.error || webhookURLFieldState.error) {
+    if (nameFieldState.error || webhookURLFieldState.error || clientDeactivateThresholdState.error) {
       setUpdateFieldInfo((info) => ({
         ...info,
         state: 'error',
         message: formErrors[updateFieldInfo.target as keyof UpdatableProjectFields]?.message || '',
       }));
     }
-  }, [formErrors, updateFieldInfo.state, updateFieldInfo.target, nameFieldState.error, webhookURLFieldState.error]);
+  }, [formErrors, updateFieldInfo.state, updateFieldInfo.target, nameFieldState.error, webhookURLFieldState.error, clientDeactivateThresholdState.error]);
 
   useEffect(() => {
     if (isSuccess) {
@@ -146,6 +152,7 @@ export function Settings() {
         navList={[
           { name: 'General', id: 'general' },
           { name: 'Webhook', id: 'webhook' },
+          { name: 'Advanced', id: 'advanced' },
         ]}
       />
       <div className="box_right">
@@ -287,6 +294,62 @@ export function Settings() {
                     </div>
                   );
                 })}
+              </dd>
+            </dl>
+          </div>
+          <div className="section setting_box" id="advanced">
+            <div className="setting_title">
+              <strong className="text">Advanced</strong>
+            </div>
+            <dl className="sub_info">
+              <dt className="sub_title">Client Deactivate Threshold</dt>
+              <dd className="sub_desc">
+                <div
+                  className={classNames('input_field_box', {
+                    is_error: checkFieldState('clientDeactivateThreshold', 'error'),
+                    is_success: checkFieldState('clientDeactivateThreshold', 'success'),
+                  })}
+                >
+                  <InputTextField
+                    reset={() => {
+                      resetForm();
+                      resetUpdateFieldInfo();
+                    }}
+                    {...register('clientDeactivateThreshold', {
+                      required: 'Client Deactivate Threshold is required',
+                      pattern: {
+                        value: /^(\d{1,2}h\s?)?(\d{1,2}m\s?)?(\d{1,2}s)?$/,
+                        message:
+                        'Client Deactivate Threshold should be a signed sequence of decimal numbers, each with a unit suffix, such as "23h30m10s" or "2h45m"',
+                      },
+                      onChange: async () => {
+                        await trigger('clientDeactivateThreshold');
+                      },
+                    })}
+                    onChange={(e) => {
+                      setUpdateFieldInfo((info) => ({ ...info, target: 'clientDeactivateThreshold' }));
+                      clientDeactivateThreshold.onChange(e.target.value);
+                    }}
+                    id="clientDeactivateThreshold"
+                    label="clientDeactivateThreshold"
+                    blindLabel={true}
+                    fieldUtil={true}
+                    placeholder={'24h00m00s'}
+                    state={
+                      checkFieldState('clientDeactivateThreshold', 'success')
+                        ? 'success'
+                        : checkFieldState('clientDeactivateThreshold', 'error')
+                        ? 'error'
+                        : undefined
+                    }
+                    helperText={
+                      updateFieldInfo.target === 'clientDeactivateThreshold' && updateFieldInfo.state !== null
+                        ? updateFieldInfo.message
+                        : undefined
+                    }
+                    onSuccessEnd={resetUpdateFieldInfo}
+                  />
+                </div>
               </dd>
             </dl>
           </div>

--- a/src/features/projects/projectsSlice.ts
+++ b/src/features/projects/projectsSlice.ts
@@ -54,6 +54,7 @@ export type ProjectUpdateFields = {
   name: string;
   authWebhookURL: string;
   authWebhookMethods: Array<AuthWebhookMethod>;
+  clientDeactivateThreshold: string;
 };
 
 const initialState: ProjectsState = {
@@ -209,6 +210,11 @@ export const projectsSlice = createSlice({
           } else if (field === 'AuthWebhookMethods') {
             state.update.error = {
               target: 'authWebhookMethods',
+              message: description,
+            };
+          } else if (field === 'ClientDeactivateThreshold') {
+            state.update.error = {
+              target: 'clientDeactivateThreshold',
               message: description,
             };
           }


### PR DESCRIPTION
#### What this PR does / why we need it?

Add `ClientDeactivateThreshold` update field in project settings.

This will provide API for setting client deactivate threshold in project.

Screenshot:

<img width="1508" alt="Screenshot 2023-02-18 at 9 27 36 PM" src="https://user-images.githubusercontent.com/70474071/219867169-cbdc4a6d-3915-4f98-98b9-180a695d4438.png">

#### Any background context you want to provide?

`ClientDeactivateThreshold` is newly introduced parameter for housekeeping.

By settings this parameter, user can optimize document performance by removing unnecessary activated clients, which affects garbage collection of document.

For more information, follow: https://github.com/yorkie-team/yorkie/issues/444, https://github.com/yorkie-team/yorkie/pull/454

#### What are the relevant tickets?

Needs to be merged after this PR: https://github.com/yorkie-team/yorkie/pull/471

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
