### PR TITLE
Set minimum limit on ClientDeactivateThreshold in project settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "react-scripts": "5.0.0",
         "sass": "^1.55.0",
         "typescript": "~4.1.5",
-        "yorkie-js-sdk": "^0.3.0"
+        "yorkie-js-sdk": "^0.3.1"
       },
       "devDependencies": {
         "@types/google-protobuf": "^3.15.6",
@@ -16647,9 +16647,9 @@
       }
     },
     "node_modules/yorkie-js-sdk": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/yorkie-js-sdk/-/yorkie-js-sdk-0.3.0.tgz",
-      "integrity": "sha512-kvAEkG5B7YGuAXALKh27qWPHQUViu3MKjyr9aGXgdHF9r+1TkCd1PkT0GVyW+pBCZXtXCNoDAs+tS1f4xQ/0bw==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/yorkie-js-sdk/-/yorkie-js-sdk-0.3.2.tgz",
+      "integrity": "sha512-/e5cmK2n/zFY9vYIwvBp68oDgRo9eE95KhZaI9hlyJiFm6OW0qRgLztfOz+am2KWcZh2uOfe3BHmv7HNjE9sKQ==",
       "dependencies": {
         "@types/google-protobuf": "^3.15.5",
         "@types/long": "^4.0.1",
@@ -28577,9 +28577,9 @@
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
     },
     "yorkie-js-sdk": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/yorkie-js-sdk/-/yorkie-js-sdk-0.3.0.tgz",
-      "integrity": "sha512-kvAEkG5B7YGuAXALKh27qWPHQUViu3MKjyr9aGXgdHF9r+1TkCd1PkT0GVyW+pBCZXtXCNoDAs+tS1f4xQ/0bw==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/yorkie-js-sdk/-/yorkie-js-sdk-0.3.2.tgz",
+      "integrity": "sha512-/e5cmK2n/zFY9vYIwvBp68oDgRo9eE95KhZaI9hlyJiFm6OW0qRgLztfOz+am2KWcZh2uOfe3BHmv7HNjE9sKQ==",
       "requires": {
         "@types/google-protobuf": "^3.15.5",
         "@types/long": "^4.0.1",

--- a/src/features/projects/Settings.tsx
+++ b/src/features/projects/Settings.tsx
@@ -67,10 +67,10 @@ export function Settings() {
     control,
     name: 'authWebhookMethods',
   });
-  const { field: clientDeactivateThreshold, fieldState: clientDeactivateThresholdState } = useController({ 
-    control, 
+  const { field: clientDeactivateThreshold, fieldState: clientDeactivateThresholdState } = useController({
+    control,
     name: 'clientDeactivateThreshold',
-   });
+  });
   const checkFieldState = useCallback(
     (fieldName: keyof UpdatableProjectFields | AuthWebhookMethod, state: 'success' | 'error'): boolean => {
       return updateFieldInfo.target === fieldName && updateFieldInfo.state === state;
@@ -109,7 +109,12 @@ export function Settings() {
   );
 
   useEffect(() => {
-    if (updateFieldInfo.state !== 'success' && !nameFieldState.error && !webhookURLFieldState.error && !clientDeactivateThresholdState.error) {
+    if (
+      updateFieldInfo.state !== 'success' &&
+      !nameFieldState.error &&
+      !webhookURLFieldState.error &&
+      !clientDeactivateThresholdState.error
+    ) {
       setUpdateFieldInfo((info) => ({
         ...info,
         state: null,
@@ -123,7 +128,14 @@ export function Settings() {
         message: formErrors[updateFieldInfo.target as keyof UpdatableProjectFields]?.message || '',
       }));
     }
-  }, [formErrors, updateFieldInfo.state, updateFieldInfo.target, nameFieldState.error, webhookURLFieldState.error, clientDeactivateThresholdState.error]);
+  }, [
+    formErrors,
+    updateFieldInfo.state,
+    updateFieldInfo.target,
+    nameFieldState.error,
+    webhookURLFieldState.error,
+    clientDeactivateThresholdState.error,
+  ]);
 
   useEffect(() => {
     if (isSuccess) {
@@ -318,9 +330,9 @@ export function Settings() {
                     {...register('clientDeactivateThreshold', {
                       required: 'Client Deactivate Threshold is required',
                       pattern: {
-                        value: /^(\d{1,2}h\s?)?(\d{1,2}m\s?)?(\d{1,2}s)?$/,
+                        value: /^(\d{1,2}h\s?)(\d{1,2}m\s?)?(\d{1,2}s)?$/,
                         message:
-                        'Client Deactivate Threshold should be a signed sequence of decimal numbers, each with a unit suffix, such as "23h30m10s" or "2h45m"',
+                          'Client Deactivate Threshold should be a signed sequence of decimal numbers, each with a unit suffix, and must contain an hour prefix, such as "23h30m10s" or "2h45m"',
                       },
                       onChange: async () => {
                         await trigger('clientDeactivateThreshold');


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Set minimum limit on `ClientDeactivateThreshold` in project settings by updating regex & description.

There was no minimum value limit on `ClientDeactivateThreshold`, which may result in excessive client deactivation.
For example, if `ClientDeactivateThreshold` is set to `01s`(or any other smaller value than `housekeepingInterval`), client may deactivate every time housekeeping occurs.

#### Any background context you want to provide?

Setting minimum value limit on `ClientDeactivateThreshold` was discussed this comment: https://github.com/yorkie-team/dashboard/pull/107#discussion_r1116645765

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
