### PR TITLE
Keep previous page state

### DIFF
--- a/src/features/documents/DocumentDetail.tsx
+++ b/src/features/documents/DocumentDetail.tsx
@@ -16,7 +16,7 @@
 
 import React, { useEffect, useState } from 'react';
 import * as moment from 'moment';
-import { useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 import { useAppDispatch, useAppSelector } from 'app/hooks';
 import { selectDocumentDetail, getDocumentAsync } from './documentsSlice';
 import { Icon, Button, CodeBlock, CopyButton } from 'components';
@@ -44,7 +44,9 @@ export function DocumentDetail() {
     <div className="detail_content">
       <div className="document_header">
         <div className="title_box">
-          <Button href="../" className="btn_back" icon={<Icon type="arrowBack" />} as="link" />
+          <Link to="../" state={{ previousProjectName: projectName }} className="btn_back">
+            <Icon type="arrowBack" />
+          </Link>
           <div className="title_inner">
             <strong className="title">{document?.key}</strong>
             <span className="date">{moment.unix(document?.updatedAt!).format('MMM D, H:mm')}</span>

--- a/src/features/documents/DocumentList.tsx
+++ b/src/features/documents/DocumentList.tsx
@@ -15,7 +15,7 @@
  */
 
 import React, { useState, useCallback, useEffect } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useLocation, useParams } from 'react-router-dom';
 import * as moment from 'moment';
 import classNames from 'classnames';
 import { useAppDispatch, useAppSelector } from 'app/hooks';
@@ -28,6 +28,7 @@ export function DocumentList({ isDetailOpen = false }: { isDetailOpen?: boolean 
   const projectName = params.projectName || '';
   const documentKey = params.documentKey || '';
   const { type: queryType, documents, hasPrevious, hasNext, status } = useAppSelector(selectDocumentList);
+  const previouseProjectName = useLocation().state?.previousProjectName;
 
   const [query, SetQuery] = useState('');
   const handleChangeQuery = useCallback((e) => {
@@ -74,8 +75,10 @@ export function DocumentList({ isDetailOpen = false }: { isDetailOpen?: boolean 
   );
 
   useEffect(() => {
+    if (previouseProjectName === projectName) return;
+
     dispatch(listDocumentsAsync({ projectName, isForward: false }));
-  }, [dispatch, projectName]);
+  }, [dispatch, previouseProjectName, projectName]);
 
   return (
     <>
@@ -149,7 +152,11 @@ export function DocumentList({ isDetailOpen = false }: { isDetailOpen?: boolean 
               const { key, updatedAt } = document;
               return (
                 <li key={key} className="tbody_item">
-                  <Link to={`./${key}`} className={classNames('link', { is_active: key === documentKey })}>
+                  <Link
+                    to={`./${key}`}
+                    state={{ previousProjectName: projectName }}
+                    className={classNames('link', { is_active: key === documentKey })}
+                  >
                     <span className="td id">{key}</span>
                     {!isDetailOpen && (
                       <span className="td updated">{moment.unix(updatedAt).format('MMM D, H:mm')}</span>


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
To keep previous page state in ‘documents’ when it is needed. / It can enhance user experience.

#### Any background context you want to provide?
This is my first PR in this repository, so I have low understanding of the project.
I think maybe this is not the best practice and someone can solve this issue in a better way.

Btw about router’s `state` property, I could pass only boolean type flag value to prevent data fetching in useEffect.
However, for better scalability, I actually passed previous projectName and implemented it comparing with current projectName.
This approach will prevent errors if projectName changes only in client-side without using router in the future.

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #100

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything

---

I don’t know If I should make additional relevant tests.
And I’m not sure this PR didn’t break anything, but maybe it is..

Let me know if someone have any questions or would like me to make any additional revisions.
