### PR TITLE
Add yorkie-user-agent option to allow_headers

### DIFF
--- a/docker/envoy.yaml
+++ b/docker/envoy.yaml
@@ -30,7 +30,7 @@ static_resources:
                 allow_origin_string_match:
                 - prefix: "*"
                 allow_methods: GET, PUT, DELETE, POST, OPTIONS
-                allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout,authorization,x-api-key
+                allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-api-key,x-shard-key,x-user-agent,x-grpc-web,grpc-timeout,authorization,x-yorkie-user-agent
                 max_age: "1728000"
                 expose_headers: custom-header-1,grpc-status,grpc-message, grpc-status-details-bin
           http_filters:


### PR DESCRIPTION
#### What this PR does / why we need it?

From yorkie-js-sdk 0.3.4, yorkie user agent was added to header. 
So add the option to allow_headers in envoy.yaml file.

#### Any background context you want to provide?


#### What are the relevant tickets?
Fixes #117 

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
