### PR TITLE
Fix time format that cannot distinguish between AM/PM

### DIFF
--- a/src/features/documents/DocumentList.tsx
+++ b/src/features/documents/DocumentList.tsx
@@ -163,7 +163,9 @@ export function DocumentList({ isDetailOpen = false }: { isDetailOpen?: boolean 
                   >
                     <span className="td id">{key}</span>
                     {!isDetailOpen && (
-                      <span className="td updated">{moment.unix(updatedAt).format(`${use24HourClock ? 'MMM D, H:mm' : 'MMM D, h:mm'}`)}</span>
+                      <span className="td updated">
+                        {moment.unix(updatedAt).format(`${use24HourClock ? 'MMM D, H:mm' : 'MMM D, h:mm A'}`)}
+                      </span>
                     )}
                   </Link>
                 </li>


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
When I selected the 12-hour-format setting, I had the problem of not being able to distinguish AM/PM. So I added the relevant format.
<img width="155" alt="image" src="https://github.com/yorkie-team/dashboard/assets/57996351/4bce9472-6140-4c34-865c-ef861b2ec02e">

<img width="160" alt="image" src="https://github.com/yorkie-team/dashboard/assets/57996351/59703017-ab61-42f5-8c2b-7eeadac20a6f">

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
