### PR TITLE
Add document deletion feature to dashboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
         {
           "strings": false,
           "skipWords": [
+            "checkbox",
             "req",
             "pb",
             "nanos",

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -29,6 +29,7 @@ import {
   SearchDocumentsRequest,
   ListChangesRequest,
   GetSnapshotMetaRequest,
+  RemoveDocumentByAdminRequest,
 } from './yorkie/v1/admin_pb';
 import { UpdatableProjectFields as PbProjectFields } from './yorkie/v1/resources_pb';
 import * as PbWrappers from 'google-protobuf/google/protobuf/wrappers_pb';
@@ -212,4 +213,17 @@ export async function listDocumentHistories(
     });
   }
   return histories;
+}
+
+// removeDocumentByAdmin removes the document of the given document.
+export async function removeDocumentByAdmin(
+  projectName: string, 
+  documentKey: string,
+  forceRemoveIfAttached: boolean,
+): Promise<void> {
+  const req = new RemoveDocumentByAdminRequest();
+  req.setProjectName(projectName);
+  req.setDocumentKey(documentKey);
+  req.setForce(false);
+  await client.removeDocumentByAdmin(req);
 }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -217,13 +217,13 @@ export async function listDocumentHistories(
 
 // removeDocumentByAdmin removes the document of the given document.
 export async function removeDocumentByAdmin(
-  projectName: string, 
+  projectName: string,
   documentKey: string,
   forceRemoveIfAttached: boolean,
 ): Promise<void> {
   const req = new RemoveDocumentByAdminRequest();
   req.setProjectName(projectName);
   req.setDocumentKey(documentKey);
-  req.setForce(false);
+  req.setForce(true);
   await client.removeDocumentByAdmin(req);
 }

--- a/src/api/yorkie/v1/admin.proto
+++ b/src/api/yorkie/v1/admin.proto
@@ -115,6 +115,7 @@ message GetDocumentResponse {
 message RemoveDocumentByAdminRequest {
   string project_name = 1;
   string document_key = 2;
+  bool force = 3;
 }
 
 message RemoveDocumentByAdminResponse {}

--- a/src/api/yorkie/v1/admin_pb.d.ts
+++ b/src/api/yorkie/v1/admin_pb.d.ts
@@ -338,6 +338,9 @@ export class RemoveDocumentByAdminRequest extends jspb.Message {
   getDocumentKey(): string;
   setDocumentKey(value: string): RemoveDocumentByAdminRequest;
 
+  getForce(): boolean;
+  setForce(value: boolean): RemoveDocumentByAdminRequest;
+
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): RemoveDocumentByAdminRequest.AsObject;
   static toObject(includeInstance: boolean, msg: RemoveDocumentByAdminRequest): RemoveDocumentByAdminRequest.AsObject;
@@ -350,6 +353,7 @@ export namespace RemoveDocumentByAdminRequest {
   export type AsObject = {
     projectName: string,
     documentKey: string,
+    force: boolean,
   }
 }
 

--- a/src/api/yorkie/v1/admin_pb.js
+++ b/src/api/yorkie/v1/admin_pb.js
@@ -3025,7 +3025,8 @@ proto.yorkie.v1.RemoveDocumentByAdminRequest.prototype.toObject = function(opt_i
 proto.yorkie.v1.RemoveDocumentByAdminRequest.toObject = function(includeInstance, msg) {
   var f, obj = {
     projectName: jspb.Message.getFieldWithDefault(msg, 1, ""),
-    documentKey: jspb.Message.getFieldWithDefault(msg, 2, "")
+    documentKey: jspb.Message.getFieldWithDefault(msg, 2, ""),
+    force: jspb.Message.getBooleanFieldWithDefault(msg, 3, false)
   };
 
   if (includeInstance) {
@@ -3070,6 +3071,10 @@ proto.yorkie.v1.RemoveDocumentByAdminRequest.deserializeBinaryFromReader = funct
       var value = /** @type {string} */ (reader.readString());
       msg.setDocumentKey(value);
       break;
+    case 3:
+      var value = /** @type {boolean} */ (reader.readBool());
+      msg.setForce(value);
+      break;
     default:
       reader.skipField();
       break;
@@ -3113,6 +3118,13 @@ proto.yorkie.v1.RemoveDocumentByAdminRequest.serializeBinaryToWriter = function(
       f
     );
   }
+  f = message.getForce();
+  if (f) {
+    writer.writeBool(
+      3,
+      f
+    );
+  }
 };
 
 
@@ -3149,6 +3161,24 @@ proto.yorkie.v1.RemoveDocumentByAdminRequest.prototype.getDocumentKey = function
  */
 proto.yorkie.v1.RemoveDocumentByAdminRequest.prototype.setDocumentKey = function(value) {
   return jspb.Message.setProto3StringField(this, 2, value);
+};
+
+
+/**
+ * optional bool force = 3;
+ * @return {boolean}
+ */
+proto.yorkie.v1.RemoveDocumentByAdminRequest.prototype.getForce = function() {
+  return /** @type {boolean} */ (jspb.Message.getBooleanFieldWithDefault(this, 3, false));
+};
+
+
+/**
+ * @param {boolean} value
+ * @return {!proto.yorkie.v1.RemoveDocumentByAdminRequest} returns this
+ */
+proto.yorkie.v1.RemoveDocumentByAdminRequest.prototype.setForce = function(value) {
+  return jspb.Message.setProto3BooleanField(this, 3, value);
 };
 
 

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Yorkie Authors. All rights reserved.
+ * Copyright 2023 The Yorkie Authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,24 +17,26 @@
 import React from 'react';
 import { Icon } from 'components';
 
-export function SearchBar({
-  placeholder,
-  onSubmit,
-  children,
+export function Checkbox({
+  id,
+  checked,
+  onChange,
+  className,
   ...restProps
 }: {
-  placeholder: string;
-  onSubmit?: React.FormEventHandler<HTMLFormElement>;
+  id: string;
+  checked: boolean;
+  className?: string;
+  onChange: React.ChangeEventHandler<HTMLInputElement>;
 } & React.InputHTMLAttributes<HTMLInputElement>) {
   return (
-    <form onSubmit={onSubmit} className="search">
-      <div className="input_field_box">
-        <div className="input_inner">
-          <Icon type="search" className="icon_search" />
-          <input type="search" className="input" placeholder={placeholder} {...restProps} />
-          {children}
-        </div>
-      </div>
-    </form>
+    <label className="input_check_box is_large">
+      <input type="checkbox" className="blind" id={id} onChange={onChange} checked={checked} />
+      <em className="checkbox_ui">
+        <span className="check">
+          <Icon type="check" />
+        </span>
+      </em>
+    </label>
   );
 }

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -29,3 +29,4 @@ export * from './Breadcrumb/Breadcrumb';
 export * from './TabList/TabList';
 export * from './CodeBlock/CodeBlock';
 export * from './Navigator/Navigator';
+export * from './Checkbox/Checkbox';

--- a/src/features/documents/DocumentList.tsx
+++ b/src/features/documents/DocumentList.tsx
@@ -19,7 +19,7 @@ import { Link, useLocation, useParams } from 'react-router-dom';
 import * as moment from 'moment';
 import classNames from 'classnames';
 import { useAppDispatch, useAppSelector } from 'app/hooks';
-import { selectDocumentList, listDocumentsAsync, searchDocumentsAsync } from './documentsSlice';
+import { selectDocumentList, listDocumentsAsync, searchDocumentsAsync, removeDocumentByAdminAsync } from './documentsSlice';
 import { Button, SearchBar, Icon } from 'components';
 import { selectPreferences } from 'features/users/usersSlice';
 
@@ -78,6 +78,16 @@ export function DocumentList({ isDetailOpen = false }: { isDetailOpen?: boolean 
     [dispatch, projectName, query],
   );
 
+  const handleRemoveBtnClicked = useCallback(
+    (e, documentKey: string) => {
+      e.preventDefault();
+      const force = false;
+      dispatch(removeDocumentByAdminAsync({ projectName, documentKey, force }));
+
+      window.location.reload();
+
+  },[dispatch, projectName]);
+
   useEffect(() => {
     if (previousProjectName === projectName) return;
 
@@ -98,6 +108,7 @@ export function DocumentList({ isDetailOpen = false }: { isDetailOpen?: boolean 
           <div className="thead">
             <span className="th id">Document ID</span>
             <span className="th updated">Last updated</span>
+            <span className="th"></span>
           </div>
         )}
         {status === 'loading' && (
@@ -168,6 +179,7 @@ export function DocumentList({ isDetailOpen = false }: { isDetailOpen?: boolean 
                       </span>
                     )}
                   </Link>
+                  <Button onClick={(e:Event) => {handleRemoveBtnClicked(e, key)}} icon={<Icon type="trash" />}></Button>
                 </li>
               );
             })}

--- a/src/features/documents/documentsSlice.ts
+++ b/src/features/documents/documentsSlice.ts
@@ -150,13 +150,9 @@ export const listDocumentHistoriesAsync = createAsyncThunk(
 
 export const removeDocumentByAdminAsync = createAsyncThunk(
   'documents/removeDocumentByAdmin',
-  async (params: { 
-    projectName: string; 
-    documentKey: string;
-    force: boolean;
-  }): Promise<void> => {
+  async (params: { projectName: string; documentKey: string; force: boolean }): Promise<void> => {
     const { projectName, documentKey, force } = params;
-    await removeDocumentByAdmin(projectName, documentKey, force);  
+    await removeDocumentByAdmin(projectName, documentKey, force);
   },
 );
 

--- a/src/features/documents/documentsSlice.ts
+++ b/src/features/documents/documentsSlice.ts
@@ -23,6 +23,7 @@ import {
   searchDocuments,
   listDocumentHistories,
   DocumentHistory,
+  removeDocumentByAdmin,
 } from 'api';
 
 export interface DocumentsState {
@@ -144,6 +145,18 @@ export const listDocumentHistoriesAsync = createAsyncThunk(
       pageSize: HISTORIES_LIMIT,
       reverse: true,
     });
+  },
+);
+
+export const removeDocumentByAdminAsync = createAsyncThunk(
+  'documents/removeDocumentByAdmin',
+  async (params: { 
+    projectName: string; 
+    documentKey: string;
+    force: boolean;
+  }): Promise<void> => {
+    const { projectName, documentKey, force } = params;
+    await removeDocumentByAdmin(projectName, documentKey, force);  
   },
 );
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Add document deletion feature to dashboard.

<img width="1121" alt="Screenshot 2023-06-28 at 12 40 12 PM" src="https://github.com/yorkie-team/dashboard/assets/2059311/2dd484de-96f6-4ca5-8293-1d24486d50e9">

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
