### PR TITLE
Add document deletion feature to dashboard (document detail)

### DIFF
--- a/src/components/Icons/Icon.tsx
+++ b/src/components/Icons/Icon.tsx
@@ -58,6 +58,7 @@ import { ReactComponent as SettingSVG } from 'assets/icons/icon_setting.svg';
 import { ReactComponent as PreviousSVG } from 'assets/icons/icon_previous.svg';
 import { ReactComponent as NextSVG } from 'assets/icons/icon_next.svg';
 import { ReactComponent as DiscordSVG } from 'assets/icons/icon_discord.svg';
+import { ReactComponent as MoreLargeSVG } from 'assets/icons/icon_more_large.svg';
 
 const svgMap = {
   shortcut: <ShortcutSVG />,
@@ -102,6 +103,7 @@ const svgMap = {
   previous: <PreviousSVG />,
   next: <NextSVG />,
   discord: <DiscordSVG />,
+  moreLarge: <MoreLargeSVG />,
 };
 type SVGType = keyof typeof svgMap;
 

--- a/src/features/documents/DocumentDetail.tsx
+++ b/src/features/documents/DocumentDetail.tsx
@@ -16,12 +16,13 @@
 
 import React, { useEffect, useState } from 'react';
 import * as moment from 'moment';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams, useNavigate } from 'react-router-dom';
 import { useAppDispatch, useAppSelector } from 'app/hooks';
 import { selectDocumentDetail, getDocumentAsync, removeDocumentByAdminAsync } from './documentsSlice';
 import { Icon, Button, CodeBlock, CopyButton, Popover, Dropdown } from 'components';
 
 export function DocumentDetail() {
+  const navigate = useNavigate();
   const { document } = useAppSelector(selectDocumentDetail);
   const dispatch = useAppDispatch();
   const params = useParams();
@@ -55,33 +56,28 @@ export function DocumentDetail() {
 
           <Popover opened={opened} onChange={setOpened}>
             <Popover.Target>
-              <button type="button" className="btn_title">
-                <Icon type="gnbMenu"/>
+              <button type="button" className="btn btn_more">
+                <Icon type="moreLarge" />
               </button>
             </Popover.Target>
             <Popover.Dropdown>
               <Dropdown>
                 <Dropdown.Title>More Options</Dropdown.Title>
                 <Dropdown.List>
-                  <Dropdown.Item as="link" href={`/projects/${projectName}/documents`}>
-                    <Button.Box>
-                      <Button
-                        icon={<Icon type="trash" />}
-                        outline={false}
-                        size="sm"
-                        onClick={async () => {
-                          await dispatch(removeDocumentByAdminAsync({ projectName, documentKey: documentKey, force: false }))
-                        }}
-                      >
-                        Delete
-                      </Button>
-                    </Button.Box>
+                  <Dropdown.Item
+                    onClick={async () => {
+                      await dispatch(
+                        removeDocumentByAdminAsync({ projectName, documentKey: documentKey, force: false }),
+                      );
+                      navigate(`..`, { replace: true });
+                    }}
+                  >
+                    <Dropdown.Text highlight>Delete Document</Dropdown.Text>
                   </Dropdown.Item>
                 </Dropdown.List>
               </Dropdown>
             </Popover.Dropdown>
           </Popover>
-
         </div>
       </div>
       <div className="codeblock_header">

--- a/src/features/documents/DocumentDetail.tsx
+++ b/src/features/documents/DocumentDetail.tsx
@@ -18,8 +18,8 @@ import React, { useEffect, useState } from 'react';
 import * as moment from 'moment';
 import { Link, useParams } from 'react-router-dom';
 import { useAppDispatch, useAppSelector } from 'app/hooks';
-import { selectDocumentDetail, getDocumentAsync } from './documentsSlice';
-import { Icon, Button, CodeBlock, CopyButton } from 'components';
+import { selectDocumentDetail, getDocumentAsync, removeDocumentByAdminAsync } from './documentsSlice';
+import { Icon, Button, CodeBlock, CopyButton, Popover, Dropdown } from 'components';
 
 export function DocumentDetail() {
   const { document } = useAppSelector(selectDocumentDetail);
@@ -30,6 +30,7 @@ export function DocumentDetail() {
   const documentJSON = document ? JSON.parse(document.snapshot) : {};
   const documentJSONStr = JSON.stringify(documentJSON, null, '\t');
   const [viewType, SetViewType] = useState('code');
+  const [opened, setOpened] = useState(false);
 
   useEffect(() => {
     dispatch(
@@ -51,6 +52,36 @@ export function DocumentDetail() {
             <strong className="title">{document?.key}</strong>
             <span className="date">{moment.unix(document?.updatedAt!).format('MMM D, H:mm')}</span>
           </div>
+
+          <Popover opened={opened} onChange={setOpened}>
+            <Popover.Target>
+              <button type="button" className="btn_title">
+                <Icon type="gnbMenu"/>
+              </button>
+            </Popover.Target>
+            <Popover.Dropdown>
+              <Dropdown>
+                <Dropdown.Title>More Options</Dropdown.Title>
+                <Dropdown.List>
+                  <Dropdown.Item as="link" href={`/projects/${projectName}/documents`}>
+                    <Button.Box>
+                      <Button
+                        icon={<Icon type="trash" />}
+                        outline={false}
+                        size="sm"
+                        onClick={async () => {
+                          await dispatch(removeDocumentByAdminAsync({ projectName, documentKey: documentKey, force: false }))
+                        }}
+                      >
+                        Delete
+                      </Button>
+                    </Button.Box>
+                  </Dropdown.Item>
+                </Dropdown.List>
+              </Dropdown>
+            </Popover.Dropdown>
+          </Popover>
+
         </div>
       </div>
       <div className="codeblock_header">


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
Add document deletion feature to dashboard (document detail)


Currently looks like:
<img width="721" alt="Screen Shot 2023-07-10 at 5 18 51 PM" src="https://github.com/yorkie-team/dashboard/assets/25169078/a2b4530f-4a3a-4a49-a0ba-c1a9a7d35c8f">
<img width="770" alt="Screen Shot 2023-07-10 at 5 18 56 PM" src="https://github.com/yorkie-team/dashboard/assets/25169078/84edbc90-758a-4b02-9f8c-98d65efcbac2">


Links back to the documents list page once document is deleted.




#### Any background context you want to provide?








#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Related to #110 

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
