### PR TITLE
Remove trailing slash from base

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,6 @@ import svgr from 'vite-plugin-svgr';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
-  base: '/dashboard/',
+  base: '/dashboard',
   plugins: [react(), commonjs(), svgr(), tsconfigPaths()],
 });


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Remove trailing slash from base

If user access `/dashboard` in some environments that do not handle redirection, the page will not be visible. This commit solves the problem by removing the trailing slash from base.

Related to https://github.com/vitejs/vite/pull/10723

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated base URL configuration for improved path handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->