### PR TITLE
Bump up Yorkie to v0.4.27

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
 # Common Environment Variables
-VITE_JS_SDK_VERSION=0.4.25
+VITE_JS_SDK_VERSION=0.4.27

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "vite-plugin-svgr": "^4.2.0",
         "vite-tsconfig-paths": "^4.3.2",
         "vitest": "^1.6.0",
-        "yorkie-js-sdk": "^0.4.24"
+        "yorkie-js-sdk": "^0.4.27"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -5177,13 +5177,13 @@
       }
     },
     "node_modules/yorkie-js-sdk": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/yorkie-js-sdk/-/yorkie-js-sdk-0.4.24.tgz",
-      "integrity": "sha512-46vbyBdPttlbQihxnBkgrCFx6DF+WcRXsEh5SovPsZt3zOKBEmQEBH4K44GeFjn35A2jByaUSnjsCR+vKQ/6rQ==",
+      "version": "0.4.27",
+      "resolved": "https://registry.npmjs.org/yorkie-js-sdk/-/yorkie-js-sdk-0.4.27.tgz",
+      "integrity": "sha512-UVFXIJDg3Or8H95IoEYhebKLh8wy2thYH0IoTJzoMtJwa/EmVvNjktrCYIuovWIBa/e3QFbhQbpw+CQ7oeLBzg==",
       "dependencies": {
         "@bufbuild/protobuf": "^1.6.0",
-        "@connectrpc/connect": "^1.2.0",
-        "@connectrpc/connect-web": "^1.2.0",
+        "@connectrpc/connect": "^1.4.0",
+        "@connectrpc/connect-web": "^1.4.0",
         "long": "^5.2.0"
       },
       "engines": {
@@ -8496,13 +8496,13 @@
       "peer": true
     },
     "yorkie-js-sdk": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/yorkie-js-sdk/-/yorkie-js-sdk-0.4.24.tgz",
-      "integrity": "sha512-46vbyBdPttlbQihxnBkgrCFx6DF+WcRXsEh5SovPsZt3zOKBEmQEBH4K44GeFjn35A2jByaUSnjsCR+vKQ/6rQ==",
+      "version": "0.4.27",
+      "resolved": "https://registry.npmjs.org/yorkie-js-sdk/-/yorkie-js-sdk-0.4.27.tgz",
+      "integrity": "sha512-UVFXIJDg3Or8H95IoEYhebKLh8wy2thYH0IoTJzoMtJwa/EmVvNjktrCYIuovWIBa/e3QFbhQbpw+CQ7oeLBzg==",
       "requires": {
         "@bufbuild/protobuf": "^1.6.0",
-        "@connectrpc/connect": "^1.2.0",
-        "@connectrpc/connect-web": "^1.2.0",
+        "@connectrpc/connect": "^1.4.0",
+        "@connectrpc/connect-web": "^1.4.0",
         "long": "^5.2.0"
       }
     }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "vite-plugin-svgr": "^4.2.0",
     "vite-tsconfig-paths": "^4.3.2",
     "vitest": "^1.6.0",
-    "yorkie-js-sdk": "^0.4.24"
+    "yorkie-js-sdk": "^0.4.27"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Bump up Yorkie to v0.4.27

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated environment variables to use `VITE_JS_SDK_VERSION` 0.4.27.
	- Upgraded "yorkie-js-sdk" dependency to version 0.4.27.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->