### PR TITLE
Fix inconsistent logo size rendering

### DIFF
--- a/src/assets/styles/components/header.scss
+++ b/src/assets/styles/components/header.scss
@@ -368,6 +368,7 @@
 
   .logo {
     padding: variables.$spacing_8;
+    width: 40px;
 
     @include mixins-lib.tabletStart() {
       width: 24px;


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

This PR addresses the issue of inconsistent logo size rendering across different browsers, particularly in Safari. 

- Safari
![image](https://github.com/user-attachments/assets/6accaf3a-af88-4d86-9f65-88bd732e998f)
- others
![image](https://github.com/user-attachments/assets/364da489-9699-45d9-a68f-6612d5f33a5b)

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced header styles for better layout and responsiveness.
	- Updated logo and dropdown dimensions for improved appearance.
	- Introduced responsive design features for various components.

- **Bug Fixes**
	- Improved alignment and spacing for user account elements on mobile and tablet views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->