### PR TITLE
Prevent dark mode flash on page refresh

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,17 @@
       content="Yorkie Dashboard is an administrative tool that allows user to manage projects and documents."
     />
 
+    <script>
+      (function () {
+        const theme = window.localStorage.getItem('theme') || 'system';
+        const isDarkMode =
+          theme === 'dark' || (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+        if (isDarkMode) {
+          window.document.documentElement.classList.add('darkmode');
+          window.document.documentElement.style.colorScheme = 'dark';
+        }
+      })();
+    </script>
     <!-- Start Single Page Apps for GitHub Pages -->
     <script type="text/javascript">
       // Single Page Apps for GitHub Pages

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,7 @@
  */
 
 import React, { useEffect } from 'react';
-import './assets/styles/style.scss'
+import './assets/styles/style.scss';
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import {
   PublicRoute,
@@ -37,11 +37,36 @@ import { DocumentDetail } from 'features/documents';
 import { selectPreferences } from 'features/users/usersSlice';
 import { TestPage, ButtonView, PopoverView, DropdownView, InputView, BreadcrumbView, ModalView } from 'test';
 
+const applyTheme = (theme: 'light' | 'dark') => {
+  if (theme === 'light') {
+    window.document.documentElement.classList.remove('darkmode');
+    window.document.documentElement.style.colorScheme = 'light';
+  } else {
+    window.document.documentElement.classList.add('darkmode');
+    window.document.documentElement.style.colorScheme = 'dark';
+  }
+};
+
 function App() {
   const { theme } = useAppSelector(selectPreferences);
   useEffect(() => {
-    document.body.classList.toggle('darkmode', theme.darkMode);
+    applyTheme(theme.darkMode ? 'dark' : 'light');
   }, [theme.darkMode]);
+
+  useEffect(() => {
+    const mediaQueryList = window.matchMedia('(prefers-color-scheme: dark)');
+    const handleSystemThemeChange = (e: MediaQueryListEvent) => {
+      applyTheme(e.matches ? 'dark' : 'light');
+    };
+
+    if (theme.useSystem) {
+      applyTheme(mediaQueryList.matches ? 'dark' : 'light');
+      mediaQueryList.addEventListener('change', handleSystemThemeChange);
+    }
+    return () => {
+      mediaQueryList.removeEventListener('change', handleSystemThemeChange);
+    };
+  }, [theme.useSystem]);
 
   return (
     <Router basename={import.meta.env.BASE_URL}>

--- a/src/assets/styles/base/_common.scss
+++ b/src/assets/styles/base/_common.scss
@@ -129,6 +129,10 @@ a {
   @extend %visuallyhidden;
 }
 
+html {
+  background-color: var(--gray-000);
+}
+
 // color
 $palette: (
   'gray': (


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

This PR fixes two theme-related issues:

1. Fixed the white flash that appears when refreshing the page in dark mode. 
To solve this, we now apply dark mode styles earlier in the page load process (before First Paint), so users won't see any unwanted white flashes when refreshing.

before | after |
:--: | :--: |
![dashboard-fouc](https://github.com/user-attachments/assets/f7b315ff-c264-41c0-b598-0ec13082261e) | ![dashboard-fix](https://github.com/user-attachments/assets/854d476b-5f76-4538-b5d9-070afa8473b3)


2. Fixed system theme preference not being applied.
Previously, when using system preference settings, the app didn't respond to dark/light mode changes. Now the theme updates properly when system preferences change.

before | after |
:--: | :--: |
![dashboard-system](https://github.com/user-attachments/assets/77752e1b-97ae-49ab-a54f-bcf320b00aec) | ![dashboard-theme](https://github.com/user-attachments/assets/70fff10d-0125-457c-ae67-cb77aef913be)


#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced theme management with support for system and manual dark/light mode preferences
	- Added dynamic theme switching based on user or system settings

- **Style**
	- Updated default HTML background color to improve visual consistency

- **Chores**
	- Improved theme detection and application logic across the application

<!-- end of auto-generated comment: release notes by coderabbit.ai -->