### PR TITLE
Move link styles to common.scss for global use

### DIFF
--- a/src/assets/styles/base/_common.scss
+++ b/src/assets/styles/base/_common.scss
@@ -411,3 +411,20 @@ $shadow: (
     display: block;
   }
 }
+
+.page_link {
+  color: var(--orange-0);
+  border-bottom: 1px solid var(--orange-0);
+
+  &.icon_link {
+    &::after {
+      display: inline-block;
+      width: 13px;
+      height: 13px;
+      margin-left: 2px;
+      background: url('/assets/icons/icon_link.svg') no-repeat center;
+      content: '';
+      vertical-align: text-top;
+    }
+  }
+}

--- a/src/assets/styles/pages/admin_setting_project.scss
+++ b/src/assets/styles/pages/admin_setting_project.scss
@@ -239,21 +239,4 @@
       }
     }
   }
-
-  .page_link {
-    color: var(--orange-0);
-    border-bottom: 1px solid var(--orange-0);
-
-    &.icon_link {
-      &::after {
-        display: inline-block;
-        width: 13px;
-        height: 13px;
-        margin-left: 2px;
-        background: url('/assets/icons/icon_link.svg') no-repeat center;
-        content: '';
-        vertical-align: text-top;
-      }
-    }
-  }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Move link styles to common.scss to apply them globally across pages


#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Added enhanced link styling with a distinct color, underline, and integrated icon indicator for a more engaging visual presentation.
  - Removed the previous link styling from the project settings page to streamline the design and ensure consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->