### PR TITLE
Add MaxAttachmentsPerDocument to project configuration  

### DIFF
--- a/src/api/converter.ts
+++ b/src/api/converter.ts
@@ -49,6 +49,7 @@ export function fromProject(pbProject: PbProject): Project {
     authWebhookMethods: pbProject.authWebhookMethods as Array<AuthWebhookMethod>,
     clientDeactivateThreshold: pbProject.clientDeactivateThreshold,
     maxSubscribersPerDocument: pbProject.maxSubscribersPerDocument,
+    maxAttachmentsPerDocument: pbProject.maxAttachmentsPerDocument,
   };
 }
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -145,6 +145,7 @@ export async function updateProject(id: string, fields: UpdatableProjectFields):
       : undefined,
     clientDeactivateThreshold: fields.clientDeactivateThreshold,
     maxSubscribersPerDocument: Number(fields.maxSubscribersPerDocument),
+    maxAttachmentsPerDocument: Number(fields.maxAttachmentsPerDocument),
   };
   const res = await client.updateProject({ id, fields: pbFields });
   return converter.fromProject(res.project!);

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -41,6 +41,7 @@ export type Project = {
   authWebhookMethods: Array<AuthWebhookMethod>;
   clientDeactivateThreshold: string;
   maxSubscribersPerDocument?: number;
+  maxAttachmentsPerDocument?: number;
   publicKey: string;
   secretKey: string;
   createdAt: number;
@@ -52,6 +53,7 @@ export type UpdatableProjectFields = {
   authWebhookMethods?: Array<AuthWebhookMethod>;
   clientDeactivateThreshold?: string;
   maxSubscribersPerDocument?: number;
+  maxAttachmentsPerDocument?: number;
 };
 
 export type AuthWebhookMethod =

--- a/src/api/yorkie/v1/resources.proto
+++ b/src/api/yorkie/v1/resources.proto
@@ -301,8 +301,9 @@ message Project {
   repeated string event_webhook_events = 8;
   string client_deactivate_threshold = 9;
   int32 max_subscribers_per_document = 10;
-  google.protobuf.Timestamp created_at = 11;
-  google.protobuf.Timestamp updated_at = 12;
+  int32 max_attachments_per_document = 11;
+  google.protobuf.Timestamp created_at = 12;
+  google.protobuf.Timestamp updated_at = 13;
 }
 
 message UpdatableProjectFields {
@@ -321,6 +322,7 @@ message UpdatableProjectFields {
   EventWebhookEvents event_webhook_events = 5;
   google.protobuf.StringValue client_deactivate_threshold = 6;
   google.protobuf.Int32Value max_subscribers_per_document = 7;
+  google.protobuf.Int32Value max_attachments_per_document = 8;
 }
 
 message DocumentSummary {

--- a/src/api/yorkie/v1/resources_pb.ts
+++ b/src/api/yorkie/v1/resources_pb.ts
@@ -2224,12 +2224,17 @@ export class Project extends Message<Project> {
   maxSubscribersPerDocument = 0;
 
   /**
-   * @generated from field: google.protobuf.Timestamp created_at = 11;
+   * @generated from field: int32 max_attachments_per_document = 11;
+   */
+  maxAttachmentsPerDocument = 0;
+
+  /**
+   * @generated from field: google.protobuf.Timestamp created_at = 12;
    */
   createdAt?: Timestamp;
 
   /**
-   * @generated from field: google.protobuf.Timestamp updated_at = 12;
+   * @generated from field: google.protobuf.Timestamp updated_at = 13;
    */
   updatedAt?: Timestamp;
 
@@ -2251,8 +2256,9 @@ export class Project extends Message<Project> {
     { no: 8, name: "event_webhook_events", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
     { no: 9, name: "client_deactivate_threshold", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 10, name: "max_subscribers_per_document", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
-    { no: 11, name: "created_at", kind: "message", T: Timestamp },
-    { no: 12, name: "updated_at", kind: "message", T: Timestamp },
+    { no: 11, name: "max_attachments_per_document", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
+    { no: 12, name: "created_at", kind: "message", T: Timestamp },
+    { no: 13, name: "updated_at", kind: "message", T: Timestamp },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): Project {
@@ -2311,6 +2317,11 @@ export class UpdatableProjectFields extends Message<UpdatableProjectFields> {
    */
   maxSubscribersPerDocument?: number;
 
+  /**
+   * @generated from field: google.protobuf.Int32Value max_attachments_per_document = 8;
+   */
+  maxAttachmentsPerDocument?: number;
+
   constructor(data?: PartialMessage<UpdatableProjectFields>) {
     super();
     proto3.util.initPartial(data, this);
@@ -2326,6 +2337,7 @@ export class UpdatableProjectFields extends Message<UpdatableProjectFields> {
     { no: 5, name: "event_webhook_events", kind: "message", T: UpdatableProjectFields_EventWebhookEvents },
     { no: 6, name: "client_deactivate_threshold", kind: "message", T: StringValue },
     { no: 7, name: "max_subscribers_per_document", kind: "message", T: Int32Value },
+    { no: 8, name: "max_attachments_per_document", kind: "message", T: Int32Value },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): UpdatableProjectFields {

--- a/src/features/projects/Settings.tsx
+++ b/src/features/projects/Settings.tsx
@@ -56,6 +56,7 @@ export function Settings() {
       authWebhookMethods: [],
       clientDeactivateThreshold: '',
       maxSubscribersPerDocument: 0,
+      maxAttachmentsPerDocument: 0,
     },
   });
 
@@ -76,6 +77,10 @@ export function Settings() {
     control,
     name: 'maxSubscribersPerDocument',
   });
+  const { field: maxAttachmentsPerDocument, fieldState: maxAttachmentsPerDocumentState } = useController({
+    control,
+    name: 'maxAttachmentsPerDocument',
+  });
   const checkFieldState = useCallback(
     (fieldName: keyof UpdatableProjectFields | AuthWebhookMethod, state: 'success' | 'error'): boolean => {
       return updateFieldInfo.target === fieldName && updateFieldInfo.state === state;
@@ -94,6 +99,7 @@ export function Settings() {
       authWebhookMethods: project?.authWebhookMethods || [],
       clientDeactivateThreshold: project?.clientDeactivateThreshold || '',
       maxSubscribersPerDocument: project?.maxSubscribersPerDocument || 0,
+      maxAttachmentsPerDocument: project?.maxAttachmentsPerDocument || 0,
     });
   }, [reset, project]);
 
@@ -121,7 +127,8 @@ export function Settings() {
       !nameFieldState.error &&
       !webhookURLFieldState.error &&
       !clientDeactivateThresholdState.error &&
-      !maxSubscribersPerDocumentState.error
+      !maxSubscribersPerDocumentState.error &&
+      !maxAttachmentsPerDocumentState.error
     ) {
       setUpdateFieldInfo((info) => ({
         ...info,
@@ -133,7 +140,8 @@ export function Settings() {
       nameFieldState.error ||
       webhookURLFieldState.error ||
       clientDeactivateThresholdState.error ||
-      maxSubscribersPerDocumentState.error
+      maxSubscribersPerDocumentState.error ||
+      maxAttachmentsPerDocumentState.error
     ) {
       setUpdateFieldInfo((info) => ({
         ...info,
@@ -149,6 +157,7 @@ export function Settings() {
     webhookURLFieldState.error,
     clientDeactivateThresholdState.error,
     maxSubscribersPerDocumentState.error,
+    maxAttachmentsPerDocumentState.error,
   ]);
 
   useEffect(() => {
@@ -288,6 +297,57 @@ export function Settings() {
                     }
                     helperText={
                       updateFieldInfo.target === 'maxSubscribersPerDocument' && updateFieldInfo.state !== null
+                        ? updateFieldInfo.message
+                        : undefined
+                    }
+                    onSuccessEnd={resetUpdateFieldInfo}
+                  />
+                </div>
+              </dd>
+              <dt className="sub_title">Max Attachments Per Document</dt>
+              <dd className="sub_desc">
+                <p className="guide">
+                  Set the maximum number of attachments allowed per document.
+                </p>
+                <div
+                  className={classNames('input_field_box', {
+                    is_error: checkFieldState('maxAttachmentsPerDocument', 'error'),
+                    is_success: checkFieldState('maxAttachmentsPerDocument', 'success'),
+                  })}
+                >
+                  <InputTextField
+                    reset={() => {
+                      resetForm();
+                      resetUpdateFieldInfo();
+                    }}
+                    {...register('maxAttachmentsPerDocument', {
+                      required: 'Max Attachments Per Document is required',
+                      pattern: {
+                        value: /^[0-9]+$/,
+                        message: 'Max Attachments Per Document must be a positive integer',
+                      },
+                      onChange: async () => {
+                        await trigger('maxAttachmentsPerDocument');
+                      },
+                    })}
+                    onChange={(e) => {
+                      setUpdateFieldInfo((info) => ({ ...info, target: 'maxAttachmentsPerDocument' }));
+                      maxAttachmentsPerDocument.onChange(e.target.value);
+                    }}
+                    id="maxAttachmentsPerDocument"
+                    label="Max Attachments Per Document"
+                    blindLabel={true}
+                    fieldUtil={true}
+                    placeholder="0"
+                    state={
+                      checkFieldState('maxAttachmentsPerDocument', 'success')
+                        ? 'success'
+                        : checkFieldState('maxAttachmentsPerDocument', 'error')
+                          ? 'error'
+                          : undefined
+                    }
+                    helperText={
+                      updateFieldInfo.target === 'maxAttachmentsPerDocument' && updateFieldInfo.state !== null
                         ? updateFieldInfo.message
                         : undefined
                     }

--- a/src/features/projects/projectsSlice.ts
+++ b/src/features/projects/projectsSlice.ts
@@ -57,6 +57,7 @@ export type ProjectUpdateFields = {
   authWebhookMethods: Array<AuthWebhookMethod>;
   clientDeactivateThreshold: string;
   maxSubscribersPerDocument: number;
+  maxAttachmentsPerDocument: number;
 };
 
 const initialState: ProjectsState = {
@@ -229,6 +230,11 @@ export const projectsSlice = createSlice({
           } else if (field === 'maxSubscribersPerDocument') {
             state.update.error = {
               target: 'maxSubscribersPerDocument',
+              message: description,
+            };
+          } else if (field === 'maxAttachmentsPerDocument') {
+            state.update.error = {
+              target: 'maxAttachmentsPerDocument',
               message: description,
             };
           }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

- Add MaxAttachmentsPerDocument to Project configuration
- Added UI components in Settings to configure max attachments per document

<img width="1714" alt="image" src="https://github.com/user-attachments/assets/2db7dbb8-3308-45fb-8fca-b0d996a26377" />


#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a "Max Attachments Per Document" option in project settings, allowing users to set limits on the number of attachments per document.
  - Enhanced validation and error messaging for this setting to ensure correct and consistent user input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->