### PR TITLE
Update descriptions of Limits

### DIFF
--- a/src/features/projects/Settings.tsx
+++ b/src/features/projects/Settings.tsx
@@ -253,61 +253,19 @@ export function Settings() {
               <strong className="text">Limits</strong>
             </div>
             <dl className="sub_info">
-              <dt className="sub_title">Max Subscribers Per Document</dt>
-              <dd className="sub_desc">
-                <p className="guide">
-                  Set the maximum number of subscribers allowed per document.
-                </p>
-                <div
-                  className={classNames('input_field_box', {
-                    is_error: checkFieldState('maxSubscribersPerDocument', 'error'),
-                    is_success: checkFieldState('maxSubscribersPerDocument', 'success'),
-                  })}
-                >
-                  <InputTextField
-                    reset={() => {
-                      resetForm();
-                      resetUpdateFieldInfo();
-                    }}
-                    {...register('maxSubscribersPerDocument', {
-                      required: 'Max Subscribers Per Document is required',
-                      pattern: {
-                        value: /^[0-9]+$/,
-                        message: 'Max Subscribers Per Document must be a positive integer',
-                      },
-                      onChange: async () => {
-                        await trigger('maxSubscribersPerDocument');
-                      },
-                    })}
-                    onChange={(e) => {
-                      setUpdateFieldInfo((info) => ({ ...info, target: 'maxSubscribersPerDocument' }));
-                      maxSubscribersPerDocument.onChange(e.target.value);
-                    }}
-                    id="maxSubscribersPerDocument"
-                    label="Max Subscribers Per Document"
-                    blindLabel={true}
-                    fieldUtil={true}
-                    placeholder="0"
-                    state={
-                      checkFieldState('maxSubscribersPerDocument', 'success')
-                        ? 'success'
-                        : checkFieldState('maxSubscribersPerDocument', 'error')
-                          ? 'error'
-                          : undefined
-                    }
-                    helperText={
-                      updateFieldInfo.target === 'maxSubscribersPerDocument' && updateFieldInfo.state !== null
-                        ? updateFieldInfo.message
-                        : undefined
-                    }
-                    onSuccessEnd={resetUpdateFieldInfo}
-                  />
-                </div>
-              </dd>
               <dt className="sub_title">Max Attachments Per Document</dt>
               <dd className="sub_desc">
                 <p className="guide">
-                  Set the maximum number of attachments allowed per document.
+                  Set the maximum number of clients that can be attached to a single document simultaneously. When this
+                  limit is reached, new attachment requests will be rejected by the server.{' '}
+                  <a
+                    href="https://yorkie.dev/docs/js-sdk#max-attachments-per-document"
+                    className="page_link icon_link"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    Learn more about Max Attachments Per Document.
+                  </a>
                 </p>
                 <div
                   className={classNames('input_field_box', {
@@ -348,6 +306,66 @@ export function Settings() {
                     }
                     helperText={
                       updateFieldInfo.target === 'maxAttachmentsPerDocument' && updateFieldInfo.state !== null
+                        ? updateFieldInfo.message
+                        : undefined
+                    }
+                    onSuccessEnd={resetUpdateFieldInfo}
+                  />
+                </div>
+              </dd>
+              <dt className="sub_title">Max Subscribers Per Document</dt>
+              <dd className="sub_desc">
+                <p className="guide">
+                  Set the maximum number of clients that can be subscribed to a single document simultaneously. When
+                  this limit is reached, new subscription requests will be rejected by the server.{' '}
+                  <a
+                    href="https://yorkie.dev/docs/js-sdk#max-subscribers-per-document"
+                    className="page_link icon_link"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    Learn more about Max Subscribers Per Document.
+                  </a>
+                </p>
+                <div
+                  className={classNames('input_field_box', {
+                    is_error: checkFieldState('maxSubscribersPerDocument', 'error'),
+                    is_success: checkFieldState('maxSubscribersPerDocument', 'success'),
+                  })}
+                >
+                  <InputTextField
+                    reset={() => {
+                      resetForm();
+                      resetUpdateFieldInfo();
+                    }}
+                    {...register('maxSubscribersPerDocument', {
+                      required: 'Max Subscribers Per Document is required',
+                      pattern: {
+                        value: /^[0-9]+$/,
+                        message: 'Max Subscribers Per Document must be a positive integer',
+                      },
+                      onChange: async () => {
+                        await trigger('maxSubscribersPerDocument');
+                      },
+                    })}
+                    onChange={(e) => {
+                      setUpdateFieldInfo((info) => ({ ...info, target: 'maxSubscribersPerDocument' }));
+                      maxSubscribersPerDocument.onChange(e.target.value);
+                    }}
+                    id="maxSubscribersPerDocument"
+                    label="Max Subscribers Per Document"
+                    blindLabel={true}
+                    fieldUtil={true}
+                    placeholder="0"
+                    state={
+                      checkFieldState('maxSubscribersPerDocument', 'success')
+                        ? 'success'
+                        : checkFieldState('maxSubscribersPerDocument', 'error')
+                          ? 'error'
+                          : undefined
+                    }
+                    helperText={
+                      updateFieldInfo.target === 'maxSubscribersPerDocument' && updateFieldInfo.state !== null
                         ? updateFieldInfo.message
                         : undefined
                     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

- Update descriptions of Limits

<img width="821" alt="image" src="https://github.com/user-attachments/assets/e04c0d44-7213-4d28-801b-0191f1cfe5d3" />

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected label mismatches in the Settings page so that the maximum allowed values for document subscribers and attachments are now displayed with the proper titles and descriptions.
  
- **New Features**
  - Introduced an informative link to provide more details about the maximum attachments per document setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->