### PR TITLE
Add allowedOrigins field to Project and UpdatableProjectFields types

### DIFF
--- a/src/api/converter.ts
+++ b/src/api/converter.ts
@@ -53,6 +53,7 @@ export function fromProject(pbProject: PbProject): Project {
     clientDeactivateThreshold: pbProject.clientDeactivateThreshold,
     maxSubscribersPerDocument: pbProject.maxSubscribersPerDocument,
     maxAttachmentsPerDocument: pbProject.maxAttachmentsPerDocument,
+    allowedOrigins: pbProject.allowedOrigins,
   };
 }
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -18,7 +18,10 @@ import { Document, OpSource, VersionVector } from '@yorkie-js/sdk';
 import { createClient } from '@connectrpc/connect';
 import { createConnectTransport } from '@connectrpc/connect-web';
 import { AdminService } from './yorkie/v1/admin_connect';
-import { UpdatableProjectFields_AuthWebhookMethods as PbProjectFields_AuthWebhookMethods } from './yorkie/v1/resources_pb';
+import {
+  UpdatableProjectFields_AuthWebhookMethods as PbProjectFields_AuthWebhookMethods,
+  UpdatableProjectFields_AllowedOrigins as PbProjectFields_AllowedOrigins,
+} from './yorkie/v1/resources_pb';
 import { InterceptorBuilder } from './interceptor';
 import {
   User,
@@ -148,6 +151,9 @@ export async function updateProject(id: string, fields: UpdatableProjectFields):
     clientDeactivateThreshold: fields.clientDeactivateThreshold,
     maxSubscribersPerDocument: Number(fields.maxSubscribersPerDocument),
     maxAttachmentsPerDocument: Number(fields.maxAttachmentsPerDocument),
+    allowedOrigins: fields.allowedOrigins
+      ? new PbProjectFields_AllowedOrigins({ origins: fields.allowedOrigins.split(',') })
+      : undefined,
   };
   const res = await client.updateProject({ id, fields: pbFields });
   return converter.fromProject(res.project!);

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -41,8 +41,9 @@ export type Project = {
   authWebhookURL: string;
   authWebhookMethods: Array<AuthWebhookMethod>;
   clientDeactivateThreshold: string;
-  maxSubscribersPerDocument?: number;
-  maxAttachmentsPerDocument?: number;
+  maxSubscribersPerDocument: number;
+  maxAttachmentsPerDocument: number;
+  allowedOrigins: Array<string>;
   publicKey: string;
   secretKey: string;
   createdAt: number;
@@ -71,6 +72,7 @@ export type UpdatableProjectFields = {
   clientDeactivateThreshold?: string;
   maxSubscribersPerDocument?: number;
   maxAttachmentsPerDocument?: number;
+  allowedOrigins?: string;
 };
 
 export type AuthWebhookMethod =

--- a/src/api/yorkie/v1/resources.proto
+++ b/src/api/yorkie/v1/resources.proto
@@ -303,6 +303,7 @@ message Project {
   string client_deactivate_threshold = 9;
   int32 max_subscribers_per_document = 10;
   int32 max_attachments_per_document = 11;
+  repeated string allowed_origins = 14;
   google.protobuf.Timestamp created_at = 12;
   google.protobuf.Timestamp updated_at = 13;
 }
@@ -321,6 +322,10 @@ message UpdatableProjectFields {
     repeated string events = 1;
   }
 
+  message AllowedOrigins {
+    repeated string origins = 1;
+  }
+
   google.protobuf.StringValue name = 1;
   google.protobuf.StringValue auth_webhook_url = 2;
   AuthWebhookMethods auth_webhook_methods = 3;
@@ -329,6 +334,7 @@ message UpdatableProjectFields {
   google.protobuf.StringValue client_deactivate_threshold = 6;
   google.protobuf.Int32Value max_subscribers_per_document = 7;
   google.protobuf.Int32Value max_attachments_per_document = 8;
+  AllowedOrigins allowed_origins = 9;
 }
 
 message DocumentSummary {

--- a/src/api/yorkie/v1/resources_pb.ts
+++ b/src/api/yorkie/v1/resources_pb.ts
@@ -2235,6 +2235,11 @@ export class Project extends Message<Project> {
   maxAttachmentsPerDocument = 0;
 
   /**
+   * @generated from field: repeated string allowed_origins = 14;
+   */
+  allowedOrigins: string[] = [];
+
+  /**
    * @generated from field: google.protobuf.Timestamp created_at = 12;
    */
   createdAt?: Timestamp;
@@ -2263,6 +2268,7 @@ export class Project extends Message<Project> {
     { no: 9, name: "client_deactivate_threshold", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 10, name: "max_subscribers_per_document", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
     { no: 11, name: "max_attachments_per_document", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
+    { no: 14, name: "allowed_origins", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
     { no: 12, name: "created_at", kind: "message", T: Timestamp },
     { no: 13, name: "updated_at", kind: "message", T: Timestamp },
   ]);
@@ -2371,6 +2377,11 @@ export class UpdatableProjectFields extends Message<UpdatableProjectFields> {
    */
   maxAttachmentsPerDocument?: number;
 
+  /**
+   * @generated from field: yorkie.v1.UpdatableProjectFields.AllowedOrigins allowed_origins = 9;
+   */
+  allowedOrigins?: UpdatableProjectFields_AllowedOrigins;
+
   constructor(data?: PartialMessage<UpdatableProjectFields>) {
     super();
     proto3.util.initPartial(data, this);
@@ -2387,6 +2398,7 @@ export class UpdatableProjectFields extends Message<UpdatableProjectFields> {
     { no: 6, name: "client_deactivate_threshold", kind: "message", T: StringValue },
     { no: 7, name: "max_subscribers_per_document", kind: "message", T: Int32Value },
     { no: 8, name: "max_attachments_per_document", kind: "message", T: Int32Value },
+    { no: 9, name: "allowed_origins", kind: "message", T: UpdatableProjectFields_AllowedOrigins },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): UpdatableProjectFields {
@@ -2477,6 +2489,43 @@ export class UpdatableProjectFields_EventWebhookEvents extends Message<Updatable
 
   static equals(a: UpdatableProjectFields_EventWebhookEvents | PlainMessage<UpdatableProjectFields_EventWebhookEvents> | undefined, b: UpdatableProjectFields_EventWebhookEvents | PlainMessage<UpdatableProjectFields_EventWebhookEvents> | undefined): boolean {
     return proto3.util.equals(UpdatableProjectFields_EventWebhookEvents, a, b);
+  }
+}
+
+/**
+ * @generated from message yorkie.v1.UpdatableProjectFields.AllowedOrigins
+ */
+export class UpdatableProjectFields_AllowedOrigins extends Message<UpdatableProjectFields_AllowedOrigins> {
+  /**
+   * @generated from field: repeated string origins = 1;
+   */
+  origins: string[] = [];
+
+  constructor(data?: PartialMessage<UpdatableProjectFields_AllowedOrigins>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "yorkie.v1.UpdatableProjectFields.AllowedOrigins";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "origins", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): UpdatableProjectFields_AllowedOrigins {
+    return new UpdatableProjectFields_AllowedOrigins().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): UpdatableProjectFields_AllowedOrigins {
+    return new UpdatableProjectFields_AllowedOrigins().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): UpdatableProjectFields_AllowedOrigins {
+    return new UpdatableProjectFields_AllowedOrigins().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: UpdatableProjectFields_AllowedOrigins | PlainMessage<UpdatableProjectFields_AllowedOrigins> | undefined, b: UpdatableProjectFields_AllowedOrigins | PlainMessage<UpdatableProjectFields_AllowedOrigins> | undefined): boolean {
+    return proto3.util.equals(UpdatableProjectFields_AllowedOrigins, a, b);
   }
 }
 

--- a/src/features/projects/Settings.tsx
+++ b/src/features/projects/Settings.tsx
@@ -422,7 +422,6 @@ export function Settings() {
                         .map((origin) => origin.trim())
                         .filter((origin) => origin)
                         .join(',');
-                      console.log(normalizedValue);
                       e.target.value = normalizedValue;
                       allowedOrigins.onBlur();
                     }}

--- a/src/features/projects/projectsSlice.ts
+++ b/src/features/projects/projectsSlice.ts
@@ -70,6 +70,7 @@ export type ProjectUpdateFields = {
   clientDeactivateThreshold: string;
   maxSubscribersPerDocument: number;
   maxAttachmentsPerDocument: number;
+  allowedOrigins: string;
 };
 
 const initialState: ProjectsState = {
@@ -268,6 +269,11 @@ export const projectsSlice = createSlice({
           } else if (field === 'maxAttachmentsPerDocument') {
             state.update.error = {
               target: 'maxAttachmentsPerDocument',
+              message: description,
+            };
+          } else if (field === 'AllowedOrigins') {
+            state.update.error = {
+              target: 'allowedOrigins',
               message: description,
             };
           }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Add allowedOrigins field to Project and UpdatableProjectFields types

<img width="784" alt="Screenshot 2025-03-26 at 7 41 06 PM" src="https://github.com/user-attachments/assets/94d61bcd-457f-4d84-a682-ea5d1eda130d" />

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced project security enhancements with a new field to specify allowed origins.
	- Enabled users to update and validate a comma-separated list of origins (supported formats include valid URLs or the wildcard "*").

- **Style**
	- Updated the project settings interface by relocating the input field under the Security section, complete with descriptive helper text and improved error feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->