### PR TITLE
Update dark mode styling for tooltips and text guide

### DIFF
--- a/src/assets/styles/pages/admin_setting_account.scss
+++ b/src/assets/styles/pages/admin_setting_account.scss
@@ -158,6 +158,10 @@
       padding-top: variables.$spacing_8;
       @include mixins-lib.rfonts(13, 18, 400);
       color: var(--gray-500);
+
+      .darkmode & {
+        color: var(--gray-400);
+      }
     }
 
     .btn_box {

--- a/src/assets/styles/pages/admin_setting_project.scss
+++ b/src/assets/styles/pages/admin_setting_project.scss
@@ -127,6 +127,10 @@
       @include mixins-lib.rfonts(13, 18, 400);
       color: var(--gray-500);
 
+      .darkmode & {
+        color: var(--gray-400);
+      }
+
       @include mixins-lib.mobileStart() {
         margin-top: variables.$spacing_16;
       }

--- a/src/assets/styles/pages/admin_setting_team.scss
+++ b/src/assets/styles/pages/admin_setting_team.scss
@@ -96,6 +96,10 @@
   .guide {
     @include mixins-lib.rfonts(13, 18, 400);
     color: var(--gray-500);
+
+    .darkmode & {
+      color: var(--gray-400);
+    }
   }
 
   .input {

--- a/src/components/Chart/Chart.tsx
+++ b/src/components/Chart/Chart.tsx
@@ -32,7 +32,7 @@ export function Chart({ data, xKey, dataKey }: { data: any[]; xKey: string; data
       >
         <CartesianGrid strokeDasharray="3 3" />
         <XAxis dataKey={xKey} tickSize={0} tickMargin={10} />
-        <Tooltip />
+        <Tooltip labelStyle={{ color: '#333' }} />
         <Line type="monotone" dataKey={dataKey} stroke="orange" dot={{ r: 3 }} activeDot={{ stroke: 'none', r: 3 }} />
       </LineChart>
     </ResponsiveContainer>


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Update dark mode styling for tooltips and text guide

|before | after|
|:--:|:--:|
|<img width="155" alt="image" src="https://github.com/user-attachments/assets/4554e813-3411-4aa0-a2ca-50d7f1c49e9b" />|<img width="193" alt="image" src="https://github.com/user-attachments/assets/40d913a7-bd1e-496b-9584-ac3f00375547" />|
|<img width="308" alt="image" src="https://github.com/user-attachments/assets/0f819f70-6926-4834-b5ad-5d91fd517997" />|<img width="257" alt="image" src="https://github.com/user-attachments/assets/640494b6-e490-4902-b612-1eaba2316219" />|


#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Enhanced dark mode visuals with improved text contrast across admin settings pages.
	- Refined chart tooltip appearance with a clearer label style for better data readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->