### PR TITLE
Enhance input placeholder styling

### DIFF
--- a/src/assets/styles/components/input.scss
+++ b/src/assets/styles/components/input.scss
@@ -22,6 +22,9 @@
 
   &::placeholder {
     color: var(--gray-500);
+    opacity: 0.4;
+    font-weight: 500;
+    font-style: italic;
   }
 
   &:-webkit-autofill {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Enhance input placeholder styling

|before | after | 
|:--:|:--:|
|![image](https://github.com/user-attachments/assets/7d207b90-dab2-498c-ad9a-c752b1b1f335)|![image](https://github.com/user-attachments/assets/7bd7b2ae-f14b-40b6-82f6-bb94622697e2)|


#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Enhanced the visual appearance of input placeholders by applying a semi-transparent, bold, and italic style for a more refined look.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->