### PR TITLE
Add attachedClients to DocumentList

### DIFF
--- a/src/api/converter.ts
+++ b/src/api/converter.ts
@@ -72,6 +72,7 @@ export function fromDocumentSummary(pbDocumentSummary: PbDocumentSummary): Docum
     id: pbDocumentSummary.id,
     key: pbDocumentSummary.key,
     snapshot: pbDocumentSummary.snapshot,
+    attachedClients: pbDocumentSummary.attachedClients,
     createdAt: fromTimestamp(pbDocumentSummary.createdAt!),
     accessedAt: fromTimestamp(pbDocumentSummary.accessedAt!),
     updatedAt: fromTimestamp(pbDocumentSummary.updatedAt!),

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -18,6 +18,7 @@ export type DocumentSummary = {
   id: string;
   key: string;
   snapshot: string;
+  attachedClients: number;
   createdAt: number;
   accessedAt: number;
   updatedAt: number;

--- a/src/api/yorkie/v1/resources.proto
+++ b/src/api/yorkie/v1/resources.proto
@@ -341,6 +341,7 @@ message DocumentSummary {
   string id = 1;
   string key = 2;
   string snapshot = 3;
+  int32 attached_clients = 7;
   google.protobuf.Timestamp created_at = 4;
   google.protobuf.Timestamp accessed_at = 5;
   google.protobuf.Timestamp updated_at = 6;

--- a/src/api/yorkie/v1/resources_pb.ts
+++ b/src/api/yorkie/v1/resources_pb.ts
@@ -2549,6 +2549,11 @@ export class DocumentSummary extends Message<DocumentSummary> {
   snapshot = "";
 
   /**
+   * @generated from field: int32 attached_clients = 7;
+   */
+  attachedClients = 0;
+
+  /**
    * @generated from field: google.protobuf.Timestamp created_at = 4;
    */
   createdAt?: Timestamp;
@@ -2574,6 +2579,7 @@ export class DocumentSummary extends Message<DocumentSummary> {
     { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 2, name: "key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 3, name: "snapshot", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 7, name: "attached_clients", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
     { no: 4, name: "created_at", kind: "message", T: Timestamp },
     { no: 5, name: "accessed_at", kind: "message", T: Timestamp },
     { no: 6, name: "updated_at", kind: "message", T: Timestamp },

--- a/src/assets/styles/components/list_document.scss
+++ b/src/assets/styles/components/list_document.scss
@@ -183,7 +183,7 @@
   }
 
   .connections {
-    width: 280px;
+    width: 120px;
   }
 
   .select {
@@ -209,15 +209,6 @@
       @include mixins-lib.tabletStart() {
         @include mixins-lib.rfonts(8, 8, 500);
       }
-    }
-  }
-}
-
-.is_edit {
-  .th,
-  .td {
-    &:not(.id, .updated, .select) {
-      display: none;
     }
   }
 }

--- a/src/features/documents/DocumentDetail.tsx
+++ b/src/features/documents/DocumentDetail.tsx
@@ -21,6 +21,7 @@ import { useAppDispatch, useAppSelector } from 'app/hooks';
 import { selectPreferences } from 'features/users/usersSlice';
 import { selectDocumentDetail, getDocumentAsync, removeDocumentByAdminAsync } from './documentsSlice';
 import { Icon, Button, CodeBlock, CopyButton, Popover, Dropdown } from 'components';
+import { formatNumber } from 'utils/format';
 
 export function DocumentDetail() {
   const navigate = useNavigate();
@@ -90,6 +91,12 @@ export function DocumentDetail() {
             </Popover.Dropdown>
           </Popover>
         </div>
+        <dl className="info_list">
+          <div className="info_item">
+            <dt className="info_title">Clients</dt>
+            <dd className="info_desc">{formatNumber(document?.attachedClients)}</dd>
+          </div>
+        </dl>
       </div>
       <div className="codeblock_header">
         <div className="box_left"></div>

--- a/src/features/documents/DocumentList.tsx
+++ b/src/features/documents/DocumentList.tsx
@@ -27,6 +27,7 @@ import {
 } from './documentsSlice';
 import { Button, SearchBar, Icon, Checkbox } from 'components';
 import { selectPreferences } from 'features/users/usersSlice';
+import { formatNumber } from '../../utils/format';
 
 export function DocumentList({ isDetailOpen = false }: { isDetailOpen?: boolean }) {
   const dispatch = useAppDispatch();
@@ -128,8 +129,8 @@ export function DocumentList({ isDetailOpen = false }: { isDetailOpen?: boolean 
         {!isDetailOpen && (
           <div className="thead">
             <span className="th id">Key</span>
-            <span className="th updated">Clients</span>
             <span className="th updated">Last Updated</span>
+            <span className="th connections">Clients</span>
             <span className="th select">
               <button
                 type="button"
@@ -212,13 +213,13 @@ export function DocumentList({ isDetailOpen = false }: { isDetailOpen?: boolean 
                     <span className="td id">{key}</span>
                     {!isDetailOpen && (
                       <>
-                        <span className="td updated">{attachedClients}</span>
                         <span className="td updated">
                           {format(
                             fromUnixTime(updatedAt),
                             `MMM d${new Date().getFullYear() === fromUnixTime(updatedAt).getFullYear() ? '' : ', yyyy'}, ${use24HourClock ? 'HH:mm' : 'h:mm a'}`,
                           )}
                         </span>
+                        <span className="td connections">{formatNumber(attachedClients)}</span>
                       </>
                     )}
                   </Link>

--- a/src/features/documents/DocumentList.tsx
+++ b/src/features/documents/DocumentList.tsx
@@ -127,7 +127,8 @@ export function DocumentList({ isDetailOpen = false }: { isDetailOpen?: boolean 
       <div className="document_table is_edit">
         {!isDetailOpen && (
           <div className="thead">
-            <span className="th id">Document Key</span>
+            <span className="th id">Key</span>
+            <span className="th updated">Clients</span>
             <span className="th updated">Last Updated</span>
             <span className="th select">
               <button
@@ -200,7 +201,7 @@ export function DocumentList({ isDetailOpen = false }: { isDetailOpen?: boolean 
         {status === 'idle' && (
           <ul className="tbody_list">
             {documents.map((document) => {
-              const { key, updatedAt } = document;
+              const { key, attachedClients, updatedAt } = document;
               return (
                 <li key={key} className="tbody_item">
                   <Link
@@ -210,12 +211,15 @@ export function DocumentList({ isDetailOpen = false }: { isDetailOpen?: boolean 
                   >
                     <span className="td id">{key}</span>
                     {!isDetailOpen && (
-                      <span className="td updated">
-                        {format(
-                          fromUnixTime(updatedAt),
-                          `MMM d${new Date().getFullYear() === fromUnixTime(updatedAt).getFullYear() ? '' : ', yyyy'}, ${use24HourClock ? 'HH:mm' : 'h:mm a'}`,
-                        )}
-                      </span>
+                      <>
+                        <span className="td updated">{attachedClients}</span>
+                        <span className="td updated">
+                          {format(
+                            fromUnixTime(updatedAt),
+                            `MMM d${new Date().getFullYear() === fromUnixTime(updatedAt).getFullYear() ? '' : ', yyyy'}, ${use24HourClock ? 'HH:mm' : 'h:mm a'}`,
+                          )}
+                        </span>
+                      </>
                     )}
                   </Link>
                   {!isDetailOpen && (
@@ -241,7 +245,7 @@ export function DocumentList({ isDetailOpen = false }: { isDetailOpen?: boolean 
         )}
         {status === 'idle' && documents.length === 0 && (
           <div className="placeholder_box no_bg">
-            <p className="desc">No Document Found</p>
+            <p className="desc">There are no documents.</p>
           </div>
         )}
       </div>

--- a/src/features/documents/documentSlice.spec.ts
+++ b/src/features/documents/documentSlice.spec.ts
@@ -26,6 +26,7 @@ for (let i = 0; i < TOTAL_SIZE; i++) {
     id: `${i}`,
     key: `${i}`,
     snapshot: '',
+    attachedClients: 0,
     createdAt: 0,
     accessedAt: 0,
     updatedAt: 0,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Add attachedClients to DocumentList

<img width="1080" alt="Screenshot 2025-04-07 at 4 45 00 PM" src="https://github.com/user-attachments/assets/d86cb5a3-abb3-4c93-a771-4e00d09512f5" />

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced document summaries to now include a client count.
  - Updated the document list view with a new "Clients" column, displaying the number of associated clients.
  - Added a section in the document detail view to show the number of clients linked to each document.
  - Revised the ordering of details and updated the placeholder text when no documents are available.

- **Style**
  - Reduced the width of the connections display and removed conditional display rules for certain table elements.

- **Tests**
  - Updated test data to reflect the new client count feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->