### PR TITLE
Add document Size to DocumentDetail

### DIFF
--- a/src/api/converter.ts
+++ b/src/api/converter.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { DATE_RANGE_OPTIONS } from './types';
+import {DataSize, DATE_RANGE_OPTIONS, DocSize} from './types';
 import { Timestamp as PbTimestamp } from '@bufbuild/protobuf';
 import { User, Project, DocumentSummary, AuthWebhookMethod, FieldViolation } from './types';
 import { Change, converter, Indexable } from '@yorkie-js/sdk';
@@ -22,6 +22,8 @@ import {
   User as PbUser,
   Project as PbProject,
   DocumentSummary as PbDocumentSummary,
+  DataSize as PbDataSize,
+  DocSize as PbDocSize,
   Change as PbChange,
 } from './yorkie/v1/resources_pb';
 import { GetProjectStatsRequest_DateRange as PbDateRange } from './yorkie/v1/admin_pb';
@@ -73,7 +75,7 @@ export function fromDocumentSummary(pbDocumentSummary: PbDocumentSummary): Docum
     key: pbDocumentSummary.key,
     snapshot: pbDocumentSummary.snapshot,
     attachedClients: pbDocumentSummary.attachedClients,
-    docSize: pbDocumentSummary.documentSize,
+    docSize: fromPbDocSize(pbDocumentSummary.documentSize),
     createdAt: fromTimestamp(pbDocumentSummary.createdAt!),
     accessedAt: fromTimestamp(pbDocumentSummary.accessedAt!),
     updatedAt: fromTimestamp(pbDocumentSummary.updatedAt!),
@@ -122,4 +124,18 @@ export function toDateRange(range: keyof typeof DATE_RANGE_OPTIONS): PbDateRange
     default:
       throw new Error(`unknown range: ${range}`);
   }
+}
+
+function fromPbDataSize(pbDataSize?: PbDataSize): DataSize {
+  return {
+    data: pbDataSize?.data ?? 0,
+    meta: pbDataSize?.meta ?? 0,
+  };
+}
+
+function fromPbDocSize(pbDocSize?: PbDocSize): DocSize {
+  return {
+    live: fromPbDataSize(pbDocSize?.live),
+    gc: fromPbDataSize(pbDocSize?.gc),
+  };
 }

--- a/src/api/converter.ts
+++ b/src/api/converter.ts
@@ -73,6 +73,7 @@ export function fromDocumentSummary(pbDocumentSummary: PbDocumentSummary): Docum
     key: pbDocumentSummary.key,
     snapshot: pbDocumentSummary.snapshot,
     attachedClients: pbDocumentSummary.attachedClients,
+    docSize: pbDocumentSummary.documentSize,
     createdAt: fromTimestamp(pbDocumentSummary.createdAt!),
     accessedAt: fromTimestamp(pbDocumentSummary.accessedAt!),
     updatedAt: fromTimestamp(pbDocumentSummary.updatedAt!),

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -19,7 +19,7 @@ export type DocumentSummary = {
   key: string;
   snapshot: string;
   attachedClients: number;
-  docSize: DocSize;
+  docSize?: DocSize;
   createdAt: number;
   accessedAt: number;
   updatedAt: number;

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -19,6 +19,7 @@ export type DocumentSummary = {
   key: string;
   snapshot: string;
   attachedClients: number;
+  docSize: DocSize;
   createdAt: number;
   accessedAt: number;
   updatedAt: number;
@@ -131,3 +132,13 @@ export class RPCError extends Error {
     if (details) this.details = details;
   }
 }
+
+export type DocSize = {
+  live: DataSize;
+  gc: DataSize;
+};
+
+export type DataSize = {
+  data: number;
+  meta: number;
+};

--- a/src/api/yorkie/v1/resources.proto
+++ b/src/api/yorkie/v1/resources.proto
@@ -342,6 +342,7 @@ message DocumentSummary {
   string key = 2;
   string snapshot = 3;
   int32 attached_clients = 7;
+  DocSize document_size = 8;
   google.protobuf.Timestamp created_at = 4;
   google.protobuf.Timestamp accessed_at = 5;
   google.protobuf.Timestamp updated_at = 6;
@@ -412,4 +413,14 @@ message DocEvent {
   DocEventType type = 1;
   string publisher = 2;
   DocEventBody body = 3;
+}
+
+message DataSize {
+  int32 data = 1;
+  int32 meta = 2;
+}
+
+message DocSize {
+  DataSize live = 1;
+  DataSize gc = 2;
 }

--- a/src/api/yorkie/v1/resources_pb.ts
+++ b/src/api/yorkie/v1/resources_pb.ts
@@ -2554,6 +2554,11 @@ export class DocumentSummary extends Message<DocumentSummary> {
   attachedClients = 0;
 
   /**
+   * @generated from field: yorkie.v1.DocSize document_size = 8;
+   */
+  documentSize?: DocSize;
+
+  /**
    * @generated from field: google.protobuf.Timestamp created_at = 4;
    */
   createdAt?: Timestamp;
@@ -2580,6 +2585,7 @@ export class DocumentSummary extends Message<DocumentSummary> {
     { no: 2, name: "key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 3, name: "snapshot", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 7, name: "attached_clients", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
+    { no: 8, name: "document_size", kind: "message", T: DocSize },
     { no: 4, name: "created_at", kind: "message", T: Timestamp },
     { no: 5, name: "accessed_at", kind: "message", T: Timestamp },
     { no: 6, name: "updated_at", kind: "message", T: Timestamp },
@@ -2944,6 +2950,92 @@ export class DocEvent extends Message<DocEvent> {
 
   static equals(a: DocEvent | PlainMessage<DocEvent> | undefined, b: DocEvent | PlainMessage<DocEvent> | undefined): boolean {
     return proto3.util.equals(DocEvent, a, b);
+  }
+}
+
+/**
+ * @generated from message yorkie.v1.DataSize
+ */
+export class DataSize extends Message<DataSize> {
+  /**
+   * @generated from field: int32 data = 1;
+   */
+  data = 0;
+
+  /**
+   * @generated from field: int32 meta = 2;
+   */
+  meta = 0;
+
+  constructor(data?: PartialMessage<DataSize>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "yorkie.v1.DataSize";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "data", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
+    { no: 2, name: "meta", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): DataSize {
+    return new DataSize().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): DataSize {
+    return new DataSize().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): DataSize {
+    return new DataSize().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: DataSize | PlainMessage<DataSize> | undefined, b: DataSize | PlainMessage<DataSize> | undefined): boolean {
+    return proto3.util.equals(DataSize, a, b);
+  }
+}
+
+/**
+ * @generated from message yorkie.v1.DocSize
+ */
+export class DocSize extends Message<DocSize> {
+  /**
+   * @generated from field: yorkie.v1.DataSize live = 1;
+   */
+  live?: DataSize;
+
+  /**
+   * @generated from field: yorkie.v1.DataSize gc = 2;
+   */
+  gc?: DataSize;
+
+  constructor(data?: PartialMessage<DocSize>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "yorkie.v1.DocSize";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "live", kind: "message", T: DataSize },
+    { no: 2, name: "gc", kind: "message", T: DataSize },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): DocSize {
+    return new DocSize().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): DocSize {
+    return new DocSize().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): DocSize {
+    return new DocSize().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: DocSize | PlainMessage<DocSize> | undefined, b: DocSize | PlainMessage<DocSize> | undefined): boolean {
+    return proto3.util.equals(DocSize, a, b);
   }
 }
 

--- a/src/assets/styles/components/document_header.scss
+++ b/src/assets/styles/components/document_header.scss
@@ -97,6 +97,10 @@
         padding-top: 10px;
       }
     }
+
+    &.right_align {
+      text-align: right;
+    }
   }
 
   .info_title,

--- a/src/features/documents/DocumentDetail.tsx
+++ b/src/features/documents/DocumentDetail.tsx
@@ -21,7 +21,7 @@ import { useAppDispatch, useAppSelector } from 'app/hooks';
 import { selectPreferences } from 'features/users/usersSlice';
 import { selectDocumentDetail, getDocumentAsync, removeDocumentByAdminAsync } from './documentsSlice';
 import { Icon, Button, CodeBlock, CopyButton, Popover, Dropdown } from 'components';
-import { formatNumber } from 'utils/format';
+import {formatNumber, humanFileSize} from 'utils/format';
 
 export function DocumentDetail() {
   const navigate = useNavigate();
@@ -98,7 +98,7 @@ export function DocumentDetail() {
           </div>
           <div className="info_item right_align">
               <dt className="info_title">Size</dt>
-              <dd className="info_desc">live: {formatNumber(document.docSize.live.data + document.docSize.live.meta)}B, gc: {formatNumber(document.docSize.gc.data + document.docSize.gc.meta)}B</dd>
+              <dd className="info_desc">live: {humanFileSize(document.docSize.live.data + document.docSize.live.meta)}, gc: {humanFileSize(document.docSize.gc.data + document.docSize.gc.meta)}</dd>
             </div>
         </dl>
       </div>

--- a/src/features/documents/DocumentDetail.tsx
+++ b/src/features/documents/DocumentDetail.tsx
@@ -98,8 +98,11 @@ export function DocumentDetail() {
           </div>
           <div className="info_item right_align">
               <dt className="info_title">Size</dt>
-              <dd className="info_desc">live: {humanFileSize(document.docSize.live.data + document.docSize.live.meta)}, gc: {humanFileSize(document.docSize.gc.data + document.docSize.gc.meta)}</dd>
-            </div>
+              <dd className="info_desc">
+                live: {humanFileSize((document.docSize?.live?.data ?? 0) + (document.docSize?.live?.meta ?? 0))},
+                gc: {humanFileSize((document.docSize?.gc?.data ?? 0) + (document.docSize?.gc?.meta ?? 0))}
+              </dd>
+          </div>
         </dl>
       </div>
       <div className="codeblock_header">

--- a/src/features/documents/DocumentDetail.tsx
+++ b/src/features/documents/DocumentDetail.tsx
@@ -96,6 +96,10 @@ export function DocumentDetail() {
             <dt className="info_title">Clients</dt>
             <dd className="info_desc">{formatNumber(document?.attachedClients)}</dd>
           </div>
+          <div className="info_item right_align">
+              <dt className="info_title">Size</dt>
+              <dd className="info_desc">live: {formatNumber(document.docSize.live.data + document.docSize.live.meta)}B, gc: {formatNumber(document.docSize.gc.data + document.docSize.gc.meta)}B</dd>
+            </div>
         </dl>
       </div>
       <div className="codeblock_header">

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -9,5 +9,5 @@ export const formatNumber = (num: number | undefined) => {
 export const humanFileSize = (size: number | undefined) => {
   if (size == undefined) return 0;
   let i = size == 0 ? 0 : Math.floor(Math.log(size) / Math.log(1024));
-  return ((size / Math.pow(1024, i)).toFixed(2)) * 1 + ' ' + ['B', 'kB', 'MB', 'GB', 'TB'][i];
+  return Number((size / Math.pow(1024, i)).toFixed(2)) + ' ' + ['B', 'kB', 'MB', 'GB', 'TB'][i];
 }

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -7,7 +7,7 @@ export const formatNumber = (num: number | undefined) => {
 };
 
 export const humanFileSize = (size: number | undefined) => {
-  if (size == undefined) return 0;
+  if (size == undefined) return '0 B';
   let i = size == 0 ? 0 : Math.floor(Math.log(size) / Math.log(1024));
   return Number((size / Math.pow(1024, i)).toFixed(2)) + ' ' + ['B', 'kB', 'MB', 'GB', 'TB'][i];
 }

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -5,3 +5,9 @@ export const formatNumber = (num: number | undefined) => {
   if (num == undefined) return '0';
   return num.toLocaleString();
 };
+
+export const humanFileSize = (size: number | undefined) => {
+  if (size == undefined) return 0;
+  let i = size == 0 ? 0 : Math.floor(Math.log(size) / Math.log(1024));
+  return ((size / Math.pow(1024, i)).toFixed(2)) * 1 + ' ' + ['B', 'kB', 'MB', 'GB', 'TB'][i];
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
This PR adds functionality to display the document size on the dashboard detail page. The document size is divided into two categories: "live" and "gc." The "live" size indicates the memory usage that is actively used by the document, while the "gc" size refers to the memory usage of objects that are marked for garbage collection.

![image](https://github.com/user-attachments/assets/64591dd3-b96d-41bd-b834-616d80eecb3b)


#### Any background context you want to provide?
This feature enhances the transparency of memory usage related to documents, allowing users to better understand the performance and resource consumption of their documents on the dashboard.

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Document detail view now displays document size metrics, including "live" and "gc" sizes in a human-readable format.
  - Added a utility to format file sizes into human-readable strings.

- **Style**
  - Added right-aligned styling for document size information in the document header.

- **Documentation**
  - Updated document summary data structures to include detailed size metrics for enhanced clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->