### PR TITLE
Reset project detail on component unmount to prevent stale data

### DIFF
--- a/src/features/projects/Overview.tsx
+++ b/src/features/projects/Overview.tsx
@@ -16,7 +16,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { useAppSelector, useAppDispatch } from 'app/hooks';
-import { getProjectStatsAsync, selectProjectDetail, selectProjectStats } from './projectsSlice';
+import { getProjectStatsAsync, selectProjectDetail, selectProjectStats, resetProjectDetail } from './projectsSlice';
 import { Icon, Popover, Dropdown, Chart } from 'components';
 import { formatNumber } from 'utils';
 import { DATE_RANGE_OPTIONS } from 'api/types';
@@ -31,9 +31,13 @@ export function Overview() {
   useEffect(() => {
     if (!project) return;
     dispatch(getProjectStatsAsync([project.name, range]));
-  }, [project, range]);
+  }, [project, range, dispatch]);
 
-  console.log(stats);
+  useEffect(() => {
+    return () => {
+      dispatch(resetProjectDetail());
+    };
+  }, [dispatch]);
 
   return (
     <>

--- a/src/features/projects/projectsSlice.ts
+++ b/src/features/projects/projectsSlice.ts
@@ -148,6 +148,10 @@ export const projectsSlice = createSlice({
     resetUpdateSuccess: (state) => {
       state.update.isSuccess = false;
     },
+    resetProjectDetail: (state) => {
+      state.detail.project = null;
+      state.detail.status = 'idle';
+    },
   },
   extraReducers: (builder) => {
     builder.addCase(listProjectsAsync.pending, (state) => {
@@ -162,7 +166,6 @@ export const projectsSlice = createSlice({
     });
     builder.addCase(getProjectAsync.pending, (state) => {
       state.detail.status = 'loading';
-      state.detail.project = null;
     });
     builder.addCase(getProjectAsync.fulfilled, (state, action) => {
       state.detail.status = 'idle';
@@ -291,7 +294,7 @@ export const projectsSlice = createSlice({
   },
 });
 
-export const { resetCreateSuccess, resetUpdateSuccess } = projectsSlice.actions;
+export const { resetCreateSuccess, resetUpdateSuccess, resetProjectDetail } = projectsSlice.actions;
 
 export const selectProjectList = (state: RootState) => state.projects.list;
 export const selectProjectDetail = (state: RootState) => state.projects.detail;


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Fix an issue where navigating to a new project page would show stale data from the previous project, causing the appearance of duplicate API calls and poor user experience.
Project detail state is properly reset when leaving the `Overview` page, ensuring clean state for the next project.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/yorkie-team/dashboard/pull/222#issuecomment-2969484644

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
