### PR TITLE
Fix pprof command flag in docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   yorkie:
     image: 'yorkieteam/yorkie:latest'
     container_name: 'yorkie'
-    command: ['server', '--enable-pprof']
+    command: ['server', '--pprof-enabled']
     restart: always
     ports:
       - '8080:8080'


### PR DESCRIPTION
#### What this PR does / why we need it?
Replaced `--enable-pprof`flag (deprecated) to `--pprof-enabled`flag.

#### Any background context you want to provide?
The --enable-pprof flag has been replaced with --pprof-enabled the Yorkie server in https://github.com/yorkie-team/yorkie/pull/1364

#### What are the relevant tickets?
Fixes #229 

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the profiling flag for the "yorkie" service in the Docker Compose configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->