### PR TITLE
Reflect recent AdminAPI changes to dashboard

### DIFF
--- a/src/api/yorkie/v1/admin.proto
+++ b/src/api/yorkie/v1/admin.proto
@@ -134,8 +134,7 @@ message GetProjectStatsRequest {
     DATE_RANGE_LAST_12M = 4;
   }
 
-  string project_name = 1;
-  DateRange date_range = 2;
+  DateRange date_range = 1;
 }
 
 message GetProjectStatsResponse {
@@ -146,9 +145,8 @@ message GetProjectStatsResponse {
 }
 
 message CreateDocumentRequest {
-  string project_name = 1;
-  string document_key = 2;
-  string initial_root = 3;
+  string document_key = 1;
+  string initial_root = 2;
 }
 
 message CreateDocumentResponse {
@@ -156,11 +154,10 @@ message CreateDocumentResponse {
 }
 
 message ListDocumentsRequest {
-  string project_name = 1;
-  string previous_id = 2;
-  int32 page_size = 3;
-  bool is_forward = 4;
-  bool include_root = 5;
+  string previous_id = 1;
+  int32 page_size = 2;
+  bool is_forward = 3;
+  bool include_root = 4;
 }
 
 message ListDocumentsResponse {
@@ -168,8 +165,7 @@ message ListDocumentsResponse {
 }
 
 message GetDocumentRequest {
-  string project_name = 1;
-  string document_key = 2;
+  string document_key = 1;
 }
 
 message GetDocumentResponse {
@@ -177,10 +173,9 @@ message GetDocumentResponse {
 }
 
 message GetDocumentsRequest {
-  string project_name = 1;
-  repeated string document_keys = 2;
-  bool include_root = 3;
-  bool include_presences = 4;
+  repeated string document_keys = 1;
+  bool include_root = 2;
+  bool include_presences = 3;
 }
 
 message GetDocumentsResponse {
@@ -188,10 +183,9 @@ message GetDocumentsResponse {
 }
 
 message UpdateDocumentRequest {
-  string project_name = 1;
-  string document_key = 2;
-  string root = 3;
-  string schema_key = 4;
+  string document_key = 1;
+  string root = 2;
+  string schema_key = 3;
 }
 
 message UpdateDocumentResponse {
@@ -199,17 +193,15 @@ message UpdateDocumentResponse {
 }
 
 message RemoveDocumentByAdminRequest {
-  string project_name = 1;
-  string document_key = 2;
-  bool force = 3;
+  string document_key = 1;
+  bool force = 2;
 }
 
 message RemoveDocumentByAdminResponse {}
 
 message GetSnapshotMetaRequest {
-  string project_name = 1;
-  string document_key = 2;
-  int64 server_seq = 3;
+  string document_key = 1;
+  int64 server_seq = 2;
 }
 
 message GetSnapshotMetaResponse {
@@ -219,9 +211,8 @@ message GetSnapshotMetaResponse {
 }
 
 message SearchDocumentsRequest {
-  string project_name = 1;
-  string query = 2;
-  int32  page_size = 3; 
+  string query = 1;
+  int32  page_size = 2;
 }
 
 message SearchDocumentsResponse {
@@ -230,11 +221,10 @@ message SearchDocumentsResponse {
 }
 
 message ListChangesRequest {
-  string project_name = 1;
-  string document_key = 2;
-  int64 previous_seq = 3;
-  int32  page_size = 4; 
-  bool   is_forward = 5;
+  string document_key = 1;
+  int64 previous_seq = 2;
+  int32  page_size = 3;
+  bool   is_forward = 4;
 }
 
 message ListChangesResponse {
@@ -242,11 +232,10 @@ message ListChangesResponse {
 }
 
 message CreateSchemaRequest {
-  string project_name = 1;
-  string schema_name = 2;
-  int32 schema_version = 3;
-  string schema_body = 4;
-  repeated Rule rules = 5;
+  string schema_name = 1;
+  int32 schema_version = 2;
+  string schema_body = 3;
+  repeated Rule rules = 4;
 }
 
 message CreateSchemaResponse {
@@ -254,7 +243,6 @@ message CreateSchemaResponse {
 }
 
 message ListSchemasRequest {
-  string project_name = 1;
 }
 
 message ListSchemasResponse {
@@ -262,9 +250,8 @@ message ListSchemasResponse {
 }
 
 message GetSchemaRequest {
-  string project_name = 1;
-  string schema_name = 2;
-  int32 version = 3;
+  string schema_name = 1;
+  int32 version = 2;
 }
 
 message GetSchemaResponse {
@@ -272,8 +259,7 @@ message GetSchemaResponse {
 }
 
 message GetSchemasRequest {
-  string project_name = 1;
-  string schema_name = 2;
+  string schema_name = 1;
 }
 
 message GetSchemasResponse {
@@ -281,9 +267,8 @@ message GetSchemasResponse {
 }
 
 message RemoveSchemaRequest {
-  string project_name = 1;
-  string schema_name = 2;
-  int32 version = 3;
+  string schema_name = 1;
+  int32 version = 2;
 }
 
 message RemoveSchemaResponse {}

--- a/src/api/yorkie/v1/admin_pb.ts
+++ b/src/api/yorkie/v1/admin_pb.ts
@@ -637,12 +637,7 @@ export class UpdateProjectResponse extends Message<UpdateProjectResponse> {
  */
 export class GetProjectStatsRequest extends Message<GetProjectStatsRequest> {
   /**
-   * @generated from field: string project_name = 1;
-   */
-  projectName = "";
-
-  /**
-   * @generated from field: yorkie.v1.GetProjectStatsRequest.DateRange date_range = 2;
+   * @generated from field: yorkie.v1.GetProjectStatsRequest.DateRange date_range = 1;
    */
   dateRange = GetProjectStatsRequest_DateRange.UNSPECIFIED;
 
@@ -654,8 +649,7 @@ export class GetProjectStatsRequest extends Message<GetProjectStatsRequest> {
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "yorkie.v1.GetProjectStatsRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "project_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 2, name: "date_range", kind: "enum", T: proto3.getEnumType(GetProjectStatsRequest_DateRange) },
+    { no: 1, name: "date_range", kind: "enum", T: proto3.getEnumType(GetProjectStatsRequest_DateRange) },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): GetProjectStatsRequest {
@@ -773,17 +767,12 @@ export class GetProjectStatsResponse extends Message<GetProjectStatsResponse> {
  */
 export class CreateDocumentRequest extends Message<CreateDocumentRequest> {
   /**
-   * @generated from field: string project_name = 1;
-   */
-  projectName = "";
-
-  /**
-   * @generated from field: string document_key = 2;
+   * @generated from field: string document_key = 1;
    */
   documentKey = "";
 
   /**
-   * @generated from field: string initial_root = 3;
+   * @generated from field: string initial_root = 2;
    */
   initialRoot = "";
 
@@ -795,9 +784,8 @@ export class CreateDocumentRequest extends Message<CreateDocumentRequest> {
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "yorkie.v1.CreateDocumentRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "project_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 2, name: "document_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 3, name: "initial_root", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 1, name: "document_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "initial_root", kind: "scalar", T: 9 /* ScalarType.STRING */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): CreateDocumentRequest {
@@ -859,27 +847,22 @@ export class CreateDocumentResponse extends Message<CreateDocumentResponse> {
  */
 export class ListDocumentsRequest extends Message<ListDocumentsRequest> {
   /**
-   * @generated from field: string project_name = 1;
-   */
-  projectName = "";
-
-  /**
-   * @generated from field: string previous_id = 2;
+   * @generated from field: string previous_id = 1;
    */
   previousId = "";
 
   /**
-   * @generated from field: int32 page_size = 3;
+   * @generated from field: int32 page_size = 2;
    */
   pageSize = 0;
 
   /**
-   * @generated from field: bool is_forward = 4;
+   * @generated from field: bool is_forward = 3;
    */
   isForward = false;
 
   /**
-   * @generated from field: bool include_root = 5;
+   * @generated from field: bool include_root = 4;
    */
   includeRoot = false;
 
@@ -891,11 +874,10 @@ export class ListDocumentsRequest extends Message<ListDocumentsRequest> {
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "yorkie.v1.ListDocumentsRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "project_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 2, name: "previous_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 3, name: "page_size", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
-    { no: 4, name: "is_forward", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
-    { no: 5, name: "include_root", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
+    { no: 1, name: "previous_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "page_size", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
+    { no: 3, name: "is_forward", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
+    { no: 4, name: "include_root", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ListDocumentsRequest {
@@ -957,12 +939,7 @@ export class ListDocumentsResponse extends Message<ListDocumentsResponse> {
  */
 export class GetDocumentRequest extends Message<GetDocumentRequest> {
   /**
-   * @generated from field: string project_name = 1;
-   */
-  projectName = "";
-
-  /**
-   * @generated from field: string document_key = 2;
+   * @generated from field: string document_key = 1;
    */
   documentKey = "";
 
@@ -974,8 +951,7 @@ export class GetDocumentRequest extends Message<GetDocumentRequest> {
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "yorkie.v1.GetDocumentRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "project_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 2, name: "document_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 1, name: "document_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): GetDocumentRequest {
@@ -1037,22 +1013,17 @@ export class GetDocumentResponse extends Message<GetDocumentResponse> {
  */
 export class GetDocumentsRequest extends Message<GetDocumentsRequest> {
   /**
-   * @generated from field: string project_name = 1;
-   */
-  projectName = "";
-
-  /**
-   * @generated from field: repeated string document_keys = 2;
+   * @generated from field: repeated string document_keys = 1;
    */
   documentKeys: string[] = [];
 
   /**
-   * @generated from field: bool include_root = 3;
+   * @generated from field: bool include_root = 2;
    */
   includeRoot = false;
 
   /**
-   * @generated from field: bool include_presences = 4;
+   * @generated from field: bool include_presences = 3;
    */
   includePresences = false;
 
@@ -1064,10 +1035,9 @@ export class GetDocumentsRequest extends Message<GetDocumentsRequest> {
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "yorkie.v1.GetDocumentsRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "project_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 2, name: "document_keys", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
-    { no: 3, name: "include_root", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
-    { no: 4, name: "include_presences", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
+    { no: 1, name: "document_keys", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
+    { no: 2, name: "include_root", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
+    { no: 3, name: "include_presences", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): GetDocumentsRequest {
@@ -1129,22 +1099,17 @@ export class GetDocumentsResponse extends Message<GetDocumentsResponse> {
  */
 export class UpdateDocumentRequest extends Message<UpdateDocumentRequest> {
   /**
-   * @generated from field: string project_name = 1;
-   */
-  projectName = "";
-
-  /**
-   * @generated from field: string document_key = 2;
+   * @generated from field: string document_key = 1;
    */
   documentKey = "";
 
   /**
-   * @generated from field: string root = 3;
+   * @generated from field: string root = 2;
    */
   root = "";
 
   /**
-   * @generated from field: string schema_key = 4;
+   * @generated from field: string schema_key = 3;
    */
   schemaKey = "";
 
@@ -1156,10 +1121,9 @@ export class UpdateDocumentRequest extends Message<UpdateDocumentRequest> {
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "yorkie.v1.UpdateDocumentRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "project_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 2, name: "document_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 3, name: "root", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 4, name: "schema_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 1, name: "document_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "root", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 3, name: "schema_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): UpdateDocumentRequest {
@@ -1221,17 +1185,12 @@ export class UpdateDocumentResponse extends Message<UpdateDocumentResponse> {
  */
 export class RemoveDocumentByAdminRequest extends Message<RemoveDocumentByAdminRequest> {
   /**
-   * @generated from field: string project_name = 1;
-   */
-  projectName = "";
-
-  /**
-   * @generated from field: string document_key = 2;
+   * @generated from field: string document_key = 1;
    */
   documentKey = "";
 
   /**
-   * @generated from field: bool force = 3;
+   * @generated from field: bool force = 2;
    */
   force = false;
 
@@ -1243,9 +1202,8 @@ export class RemoveDocumentByAdminRequest extends Message<RemoveDocumentByAdminR
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "yorkie.v1.RemoveDocumentByAdminRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "project_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 2, name: "document_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 3, name: "force", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
+    { no: 1, name: "document_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "force", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): RemoveDocumentByAdminRequest {
@@ -1301,17 +1259,12 @@ export class RemoveDocumentByAdminResponse extends Message<RemoveDocumentByAdmin
  */
 export class GetSnapshotMetaRequest extends Message<GetSnapshotMetaRequest> {
   /**
-   * @generated from field: string project_name = 1;
-   */
-  projectName = "";
-
-  /**
-   * @generated from field: string document_key = 2;
+   * @generated from field: string document_key = 1;
    */
   documentKey = "";
 
   /**
-   * @generated from field: int64 server_seq = 3;
+   * @generated from field: int64 server_seq = 2;
    */
   serverSeq = protoInt64.zero;
 
@@ -1323,9 +1276,8 @@ export class GetSnapshotMetaRequest extends Message<GetSnapshotMetaRequest> {
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "yorkie.v1.GetSnapshotMetaRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "project_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 2, name: "document_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 3, name: "server_seq", kind: "scalar", T: 3 /* ScalarType.INT64 */ },
+    { no: 1, name: "document_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "server_seq", kind: "scalar", T: 3 /* ScalarType.INT64 */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): GetSnapshotMetaRequest {
@@ -1399,17 +1351,12 @@ export class GetSnapshotMetaResponse extends Message<GetSnapshotMetaResponse> {
  */
 export class SearchDocumentsRequest extends Message<SearchDocumentsRequest> {
   /**
-   * @generated from field: string project_name = 1;
-   */
-  projectName = "";
-
-  /**
-   * @generated from field: string query = 2;
+   * @generated from field: string query = 1;
    */
   query = "";
 
   /**
-   * @generated from field: int32 page_size = 3;
+   * @generated from field: int32 page_size = 2;
    */
   pageSize = 0;
 
@@ -1421,9 +1368,8 @@ export class SearchDocumentsRequest extends Message<SearchDocumentsRequest> {
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "yorkie.v1.SearchDocumentsRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "project_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 2, name: "query", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 3, name: "page_size", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
+    { no: 1, name: "query", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "page_size", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): SearchDocumentsRequest {
@@ -1491,27 +1437,22 @@ export class SearchDocumentsResponse extends Message<SearchDocumentsResponse> {
  */
 export class ListChangesRequest extends Message<ListChangesRequest> {
   /**
-   * @generated from field: string project_name = 1;
-   */
-  projectName = "";
-
-  /**
-   * @generated from field: string document_key = 2;
+   * @generated from field: string document_key = 1;
    */
   documentKey = "";
 
   /**
-   * @generated from field: int64 previous_seq = 3;
+   * @generated from field: int64 previous_seq = 2;
    */
   previousSeq = protoInt64.zero;
 
   /**
-   * @generated from field: int32 page_size = 4;
+   * @generated from field: int32 page_size = 3;
    */
   pageSize = 0;
 
   /**
-   * @generated from field: bool is_forward = 5;
+   * @generated from field: bool is_forward = 4;
    */
   isForward = false;
 
@@ -1523,11 +1464,10 @@ export class ListChangesRequest extends Message<ListChangesRequest> {
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "yorkie.v1.ListChangesRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "project_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 2, name: "document_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 3, name: "previous_seq", kind: "scalar", T: 3 /* ScalarType.INT64 */ },
-    { no: 4, name: "page_size", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
-    { no: 5, name: "is_forward", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
+    { no: 1, name: "document_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "previous_seq", kind: "scalar", T: 3 /* ScalarType.INT64 */ },
+    { no: 3, name: "page_size", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
+    { no: 4, name: "is_forward", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ListChangesRequest {
@@ -1589,27 +1529,22 @@ export class ListChangesResponse extends Message<ListChangesResponse> {
  */
 export class CreateSchemaRequest extends Message<CreateSchemaRequest> {
   /**
-   * @generated from field: string project_name = 1;
-   */
-  projectName = "";
-
-  /**
-   * @generated from field: string schema_name = 2;
+   * @generated from field: string schema_name = 1;
    */
   schemaName = "";
 
   /**
-   * @generated from field: int32 schema_version = 3;
+   * @generated from field: int32 schema_version = 2;
    */
   schemaVersion = 0;
 
   /**
-   * @generated from field: string schema_body = 4;
+   * @generated from field: string schema_body = 3;
    */
   schemaBody = "";
 
   /**
-   * @generated from field: repeated yorkie.v1.Rule rules = 5;
+   * @generated from field: repeated yorkie.v1.Rule rules = 4;
    */
   rules: Rule[] = [];
 
@@ -1621,11 +1556,10 @@ export class CreateSchemaRequest extends Message<CreateSchemaRequest> {
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "yorkie.v1.CreateSchemaRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "project_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 2, name: "schema_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 3, name: "schema_version", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
-    { no: 4, name: "schema_body", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 5, name: "rules", kind: "message", T: Rule, repeated: true },
+    { no: 1, name: "schema_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "schema_version", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
+    { no: 3, name: "schema_body", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 4, name: "rules", kind: "message", T: Rule, repeated: true },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): CreateSchemaRequest {
@@ -1686,11 +1620,6 @@ export class CreateSchemaResponse extends Message<CreateSchemaResponse> {
  * @generated from message yorkie.v1.ListSchemasRequest
  */
 export class ListSchemasRequest extends Message<ListSchemasRequest> {
-  /**
-   * @generated from field: string project_name = 1;
-   */
-  projectName = "";
-
   constructor(data?: PartialMessage<ListSchemasRequest>) {
     super();
     proto3.util.initPartial(data, this);
@@ -1699,7 +1628,6 @@ export class ListSchemasRequest extends Message<ListSchemasRequest> {
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "yorkie.v1.ListSchemasRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "project_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ListSchemasRequest {
@@ -1761,17 +1689,12 @@ export class ListSchemasResponse extends Message<ListSchemasResponse> {
  */
 export class GetSchemaRequest extends Message<GetSchemaRequest> {
   /**
-   * @generated from field: string project_name = 1;
-   */
-  projectName = "";
-
-  /**
-   * @generated from field: string schema_name = 2;
+   * @generated from field: string schema_name = 1;
    */
   schemaName = "";
 
   /**
-   * @generated from field: int32 version = 3;
+   * @generated from field: int32 version = 2;
    */
   version = 0;
 
@@ -1783,9 +1706,8 @@ export class GetSchemaRequest extends Message<GetSchemaRequest> {
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "yorkie.v1.GetSchemaRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "project_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 2, name: "schema_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 3, name: "version", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
+    { no: 1, name: "schema_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "version", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): GetSchemaRequest {
@@ -1847,12 +1769,7 @@ export class GetSchemaResponse extends Message<GetSchemaResponse> {
  */
 export class GetSchemasRequest extends Message<GetSchemasRequest> {
   /**
-   * @generated from field: string project_name = 1;
-   */
-  projectName = "";
-
-  /**
-   * @generated from field: string schema_name = 2;
+   * @generated from field: string schema_name = 1;
    */
   schemaName = "";
 
@@ -1864,8 +1781,7 @@ export class GetSchemasRequest extends Message<GetSchemasRequest> {
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "yorkie.v1.GetSchemasRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "project_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 2, name: "schema_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 1, name: "schema_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): GetSchemasRequest {
@@ -1927,17 +1843,12 @@ export class GetSchemasResponse extends Message<GetSchemasResponse> {
  */
 export class RemoveSchemaRequest extends Message<RemoveSchemaRequest> {
   /**
-   * @generated from field: string project_name = 1;
-   */
-  projectName = "";
-
-  /**
-   * @generated from field: string schema_name = 2;
+   * @generated from field: string schema_name = 1;
    */
   schemaName = "";
 
   /**
-   * @generated from field: int32 version = 3;
+   * @generated from field: int32 version = 2;
    */
   version = 0;
 
@@ -1949,9 +1860,8 @@ export class RemoveSchemaRequest extends Message<RemoveSchemaRequest> {
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "yorkie.v1.RemoveSchemaRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "project_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 2, name: "schema_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 3, name: "version", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
+    { no: 1, name: "schema_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "version", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): RemoveSchemaRequest {

--- a/src/api/yorkie/v1/resources.proto
+++ b/src/api/yorkie/v1/resources.proto
@@ -58,7 +58,7 @@ message Change {
 
 message ChangeID {
   uint32 client_seq = 1;
-  int64 server_seq = 2;
+  int64 server_seq = 2; 
   int64 lamport = 3;
   bytes actor_id = 4;
   VersionVector version_vector = 5;
@@ -100,16 +100,6 @@ message Operation {
     string content = 5;
     TimeTicket executed_at = 6;
     map<string, string> attributes = 7;
-  }
-  // NOTE(hackerwins): Select Operation is not used in the current version.
-  // In the previous version, it was used to represent selection of Text.
-  // However, it has been replaced by Presence now. It is retained for backward
-  // compatibility purposes.
-  message Select {
-    TimeTicket parent_created_at = 1;
-    TextNodePos from = 2;
-    TextNodePos to = 3;
-    TimeTicket executed_at = 4;
   }
   message Style {
     TimeTicket parent_created_at = 1;
@@ -155,7 +145,6 @@ message Operation {
     Move move = 3;
     Remove remove = 4;
     Edit edit = 5;
-    Select select = 6;
     Style style = 7;
     Increase increase = 8;
     TreeEdit tree_edit = 9;

--- a/src/api/yorkie/v1/resources_pb.ts
+++ b/src/api/yorkie/v1/resources_pb.ts
@@ -462,12 +462,6 @@ export class Operation extends Message<Operation> {
     case: "edit";
   } | {
     /**
-     * @generated from field: yorkie.v1.Operation.Select select = 6;
-     */
-    value: Operation_Select;
-    case: "select";
-  } | {
-    /**
      * @generated from field: yorkie.v1.Operation.Style style = 7;
      */
     value: Operation_Style;
@@ -511,7 +505,6 @@ export class Operation extends Message<Operation> {
     { no: 3, name: "move", kind: "message", T: Operation_Move, oneof: "body" },
     { no: 4, name: "remove", kind: "message", T: Operation_Remove, oneof: "body" },
     { no: 5, name: "edit", kind: "message", T: Operation_Edit, oneof: "body" },
-    { no: 6, name: "select", kind: "message", T: Operation_Select, oneof: "body" },
     { no: 7, name: "style", kind: "message", T: Operation_Style, oneof: "body" },
     { no: 8, name: "increase", kind: "message", T: Operation_Increase, oneof: "body" },
     { no: 9, name: "tree_edit", kind: "message", T: Operation_TreeEdit, oneof: "body" },
@@ -822,66 +815,6 @@ export class Operation_Edit extends Message<Operation_Edit> {
 
   static equals(a: Operation_Edit | PlainMessage<Operation_Edit> | undefined, b: Operation_Edit | PlainMessage<Operation_Edit> | undefined): boolean {
     return proto3.util.equals(Operation_Edit, a, b);
-  }
-}
-
-/**
- * NOTE(hackerwins): Select Operation is not used in the current version.
- * In the previous version, it was used to represent selection of Text.
- * However, it has been replaced by Presence now. It is retained for backward
- * compatibility purposes.
- *
- * @generated from message yorkie.v1.Operation.Select
- */
-export class Operation_Select extends Message<Operation_Select> {
-  /**
-   * @generated from field: yorkie.v1.TimeTicket parent_created_at = 1;
-   */
-  parentCreatedAt?: TimeTicket;
-
-  /**
-   * @generated from field: yorkie.v1.TextNodePos from = 2;
-   */
-  from?: TextNodePos;
-
-  /**
-   * @generated from field: yorkie.v1.TextNodePos to = 3;
-   */
-  to?: TextNodePos;
-
-  /**
-   * @generated from field: yorkie.v1.TimeTicket executed_at = 4;
-   */
-  executedAt?: TimeTicket;
-
-  constructor(data?: PartialMessage<Operation_Select>) {
-    super();
-    proto3.util.initPartial(data, this);
-  }
-
-  static readonly runtime: typeof proto3 = proto3;
-  static readonly typeName = "yorkie.v1.Operation.Select";
-  static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "parent_created_at", kind: "message", T: TimeTicket },
-    { no: 2, name: "from", kind: "message", T: TextNodePos },
-    { no: 3, name: "to", kind: "message", T: TextNodePos },
-    { no: 4, name: "executed_at", kind: "message", T: TimeTicket },
-  ]);
-
-  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): Operation_Select {
-    return new Operation_Select().fromBinary(bytes, options);
-  }
-
-  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): Operation_Select {
-    return new Operation_Select().fromJson(jsonValue, options);
-  }
-
-  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): Operation_Select {
-    return new Operation_Select().fromJsonString(jsonString, options);
-  }
-
-  static equals(a: Operation_Select | PlainMessage<Operation_Select> | undefined, b: Operation_Select | PlainMessage<Operation_Select> | undefined): boolean {
-    return proto3.util.equals(Operation_Select, a, b);
   }
 }
 

--- a/src/app/middleware.ts
+++ b/src/app/middleware.ts
@@ -17,7 +17,7 @@
 import type { MiddlewareAPI, Middleware } from '@reduxjs/toolkit';
 import { RPCError, RPCStatusCode } from 'api/types';
 import { setGlobalError } from 'features/globalError/globalErrorSlice';
-import { setIsValidToken } from 'features/users/usersSlice';
+import { setIsAuthenticated } from 'features/users/usersSlice';
 import { isRejectedAction } from './appThunk';
 
 export const globalErrorHandler: Middleware = (store: MiddlewareAPI) => (next) => (action) => {
@@ -32,7 +32,7 @@ export const globalErrorHandler: Middleware = (store: MiddlewareAPI) => (next) =
   const statusCode = action.payload.error instanceof RPCError ? Number(action.payload.error.code) : null;
 
   if (statusCode === RPCStatusCode.UNAUTHENTICATED) {
-    store.dispatch(setIsValidToken(false));
+    store.dispatch(setIsAuthenticated(false));
     return result;
   }
   store.dispatch(setGlobalError({ statusCode, errorMessage }));

--- a/src/features/documents/DocumentDetail.tsx
+++ b/src/features/documents/DocumentDetail.tsx
@@ -20,16 +20,17 @@ import { Link, useParams, useNavigate } from 'react-router-dom';
 import { useAppDispatch, useAppSelector } from 'app/hooks';
 import { selectPreferences } from 'features/users/usersSlice';
 import { selectDocumentDetail, getDocumentAsync, removeDocumentByAdminAsync } from './documentsSlice';
+import { selectCurrentProject } from 'features/projects/projectsSlice';
 import { Icon, Button, CodeBlock, CopyButton, Popover, Dropdown, Modal } from 'components';
 import { formatNumber, humanFileSize } from 'utils/format';
 
 export function DocumentDetail() {
   const navigate = useNavigate();
   const { document } = useAppSelector(selectDocumentDetail);
+  const { project: currentProject } = useAppSelector(selectCurrentProject);
   const { use24HourClock } = useAppSelector(selectPreferences);
   const dispatch = useAppDispatch();
   const params = useParams();
-  const projectName = params.projectName || '';
   const documentKey = params.documentKey || '';
   const documentJSON = document ? JSON.parse(document.root) : {};
   const documentJSONStr = JSON.stringify(documentJSON, null, '\t');
@@ -38,13 +39,14 @@ export function DocumentDetail() {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   useEffect(() => {
+    if (!currentProject || !documentKey) return;
+
     dispatch(
       getDocumentAsync({
-        projectName,
         documentKey,
       }),
     );
-  }, [dispatch, projectName, documentKey]);
+  }, [dispatch, currentProject, documentKey]);
 
   if (!document) {
     return null;
@@ -55,7 +57,7 @@ export function DocumentDetail() {
       <div className="detail_content">
         <div className="document_header">
           <div className="title_box">
-            <Link to="../" state={{ previousProjectName: projectName }} className="btn_back">
+            <Link to="../" className="btn_back">
               <Icon type="arrowBack" />
             </Link>
             <div className="title_inner">
@@ -175,7 +177,7 @@ export function DocumentDetail() {
               <Button
                 color="danger"
                 onClick={async () => {
-                  await dispatch(removeDocumentByAdminAsync({ projectName, documentKey: documentKey, force: false }));
+                  await dispatch(removeDocumentByAdminAsync({ documentKey: documentKey, force: false }));
                   navigate(`..`, { replace: true });
                 }}
               >

--- a/src/features/documents/documentsSlice.ts
+++ b/src/features/documents/documentsSlice.ts
@@ -75,7 +75,6 @@ const HISTORIES_LIMIT = 20;
 export const listDocumentsAsync = createAppThunk(
   'documents/listDocuments',
   async (params: {
-    projectName: string;
     isForward: boolean;
     previousID?: string;
   }): Promise<{
@@ -83,8 +82,8 @@ export const listDocumentsAsync = createAppThunk(
     hasNext: boolean;
     hasPrevious: boolean;
   }> => {
-    const { projectName, isForward, previousID = '' } = params;
-    const documents = await listDocuments(projectName, previousID, DOCUMENTS_LIMIT + 1, isForward);
+    const { isForward, previousID = '' } = params;
+    const documents = await listDocuments(previousID, DOCUMENTS_LIMIT + 1, isForward);
 
     return getPaginationData({ data: documents, isForward, previousID, pageSize: DOCUMENTS_LIMIT });
   },
@@ -92,9 +91,9 @@ export const listDocumentsAsync = createAppThunk(
 
 export const getDocumentAsync = createAppThunk(
   'documents/getDocument',
-  async (params: { projectName: string; documentKey: string }): Promise<DocumentSummary> => {
-    const { projectName, documentKey } = params;
-    const document = await getDocument(projectName, documentKey);
+  async (params: { documentKey: string }): Promise<DocumentSummary> => {
+    const { documentKey } = params;
+    const document = await getDocument(documentKey);
     return document;
   },
 );
@@ -102,14 +101,13 @@ export const getDocumentAsync = createAppThunk(
 export const searchDocumentsAsync = createAppThunk(
   'documents/searchDocuments',
   async (params: {
-    projectName: string;
     documentQuery: string;
   }): Promise<{
     totalCount: number;
     documents: Array<DocumentSummary>;
   }> => {
-    const { projectName, documentQuery } = params;
-    const res = await searchDocuments(projectName, documentQuery, DOCUMENTS_LIMIT);
+    const { documentQuery } = params;
+    const res = await searchDocuments(documentQuery, DOCUMENTS_LIMIT);
 
     return {
       totalCount: res.totalCount,
@@ -121,7 +119,6 @@ export const searchDocumentsAsync = createAppThunk(
 export const listDocumentHistoriesAsync = createAppThunk(
   'documents/listDocumentHistories',
   async (params: {
-    projectName: string;
     documentKey: string;
     isForward: boolean;
     previousSeq?: bigint;
@@ -130,14 +127,8 @@ export const listDocumentHistoriesAsync = createAppThunk(
     hasNext: boolean;
     hasPrevious: boolean;
   }> => {
-    const { projectName, documentKey, isForward, previousSeq = 0n } = params;
-    const histories = await listDocumentHistories(
-      projectName,
-      documentKey,
-      previousSeq,
-      HISTORIES_LIMIT + 1,
-      isForward,
-    );
+    const { documentKey, isForward, previousSeq = 0n } = params;
+    const histories = await listDocumentHistories(documentKey, previousSeq, HISTORIES_LIMIT + 1, isForward);
 
     return getPaginationData({
       data: histories,
@@ -151,9 +142,9 @@ export const listDocumentHistoriesAsync = createAppThunk(
 
 export const removeDocumentByAdminAsync = createAppThunk(
   'documents/removeDocumentByAdmin',
-  async (params: { projectName: string; documentKey: string; force: boolean }): Promise<void> => {
-    const { projectName, documentKey, force } = params;
-    await removeDocumentByAdmin(projectName, documentKey, force);
+  async (params: { documentKey: string; force: boolean }): Promise<void> => {
+    const { documentKey, force } = params;
+    await removeDocumentByAdmin(documentKey, force);
   },
 );
 

--- a/src/features/projects/ProjectDropdown.tsx
+++ b/src/features/projects/ProjectDropdown.tsx
@@ -20,17 +20,20 @@ import { useParams, Link } from 'react-router-dom';
 import { useAppDispatch, useAppSelector } from 'app/hooks';
 import { Project } from 'api/types';
 import { Popover, Dropdown, Icon, Breadcrumb } from 'components';
-import { selectProjectList, listProjectsAsync } from './projectsSlice';
+import { selectProjectList, listProjectsAsync, setCurrentProjectAsync } from './projectsSlice';
 
 export function ProjectDropdown({ size = 'small' }: { size?: 'small' | 'large' }) {
   const { projectName } = useParams();
-  const { projects } = useAppSelector(selectProjectList);
+  const { projects, status } = useAppSelector(selectProjectList);
   const dispatch = useAppDispatch();
   const [opened, setOpened] = useState(false);
 
   useEffect(() => {
-    dispatch(listProjectsAsync());
-  }, [dispatch]);
+    // Only fetch if we don't have projects and we're not already loading
+    if (projects.length === 0 && status === 'idle') {
+      dispatch(listProjectsAsync());
+    }
+  }, [dispatch, projects.length, status]);
 
   useEffect(() => {
     return () => {

--- a/src/features/projects/ProjectList.tsx
+++ b/src/features/projects/ProjectList.tsx
@@ -130,6 +130,7 @@ export function ProjectList() {
   );
 
   useEffect(() => {
+    // Always fetch projects when component mounts to ensure we have the latest list
     dispatch(listProjectsAsync());
   }, [dispatch]);
 

--- a/src/features/projects/ProjectTabList.tsx
+++ b/src/features/projects/ProjectTabList.tsx
@@ -16,21 +16,41 @@
 
 import React, { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
-import { useAppDispatch } from 'app/hooks';
-import { getProjectAsync } from './projectsSlice';
+import { useAppDispatch, useAppSelector } from 'app/hooks';
+import { getProjectAsync, setCurrentProjectAsync, selectCurrentProject, selectProjectDetail } from './projectsSlice';
 import { Icon, TabList } from 'components';
 
 export function ProjectTabList() {
   let { projectName } = useParams();
   const dispatch = useAppDispatch();
+  const currentProject = useAppSelector(selectCurrentProject);
+  const projectDetail = useAppSelector(selectProjectDetail);
 
   useEffect(() => {
     if (!projectName) {
       return;
     }
 
-    dispatch(getProjectAsync(projectName));
-  }, [dispatch, projectName]);
+    // Only set current project if it's different from the current one and not loading
+    if (currentProject.project?.name !== projectName && currentProject.status === 'idle') {
+      dispatch(setCurrentProjectAsync(projectName)).then(() => {
+        // Only get project details if we don't have them and not loading
+        if (projectDetail.project?.name !== projectName && projectDetail.status === 'idle') {
+          dispatch(getProjectAsync(projectName));
+        }
+      });
+    } else if (projectDetail.project?.name !== projectName && projectDetail.status === 'idle') {
+      // If current project is already set, just get details if needed
+      dispatch(getProjectAsync(projectName));
+    }
+  }, [
+    dispatch,
+    projectName,
+    currentProject.project?.name,
+    currentProject.status,
+    projectDetail.project?.name,
+    projectDetail.status,
+  ]);
 
   return (
     <TabList>

--- a/src/features/schemas/SchemaList.tsx
+++ b/src/features/schemas/SchemaList.tsx
@@ -20,21 +20,24 @@ import { fromUnixTime, format } from 'date-fns';
 import classNames from 'classnames';
 import { useAppDispatch, useAppSelector } from 'app/hooks';
 import { selectSchemaList, listSchemasAsync } from './schemasSlice';
+import { selectCurrentProject } from 'features/projects/projectsSlice';
 import { selectPreferences } from 'features/users/usersSlice';
 import { Button, Icon } from 'components';
 
 export function SchemaList({ isDetailOpen = false }: { isDetailOpen?: boolean }) {
   const dispatch = useAppDispatch();
   const params = useParams();
-  const projectName = params.projectName || '';
   const schemaName = params.schemaName || '';
   const { schemas, status } = useAppSelector(selectSchemaList);
+  const { project: currentProject } = useAppSelector(selectCurrentProject);
   const { use24HourClock } = useAppSelector(selectPreferences);
   const url = useLocation().pathname;
 
   useEffect(() => {
-    dispatch(listSchemasAsync({ projectName }));
-  }, [dispatch, projectName]);
+    if (!currentProject) return;
+
+    dispatch(listSchemasAsync());
+  }, [dispatch, currentProject]);
 
   return (
     <>

--- a/src/features/schemas/schemasSlice.ts
+++ b/src/features/schemas/schemasSlice.ts
@@ -42,7 +42,6 @@ export interface SchemasState {
 }
 
 export type SchemaCreateFields = {
-  projectName: string;
   name: string;
   version: number;
   body: string;
@@ -69,21 +68,23 @@ const initialState: SchemasState = {
 export const createSchemaAsync = createAppThunk<Schema, SchemaCreateFields>(
   'schemas/createSchema',
   async (params: SchemaCreateFields): Promise<Schema> => {
-    const { projectName, name, version, body, ruleset } = params;
-    const schema = await createSchema(projectName, name, version, body, ruleset);
+    const { name, version, body, ruleset } = params;
+    const schema = await createSchema(name, version, body, ruleset);
     return schema;
   },
 );
 
-export const listSchemasAsync = createAppThunk(
+export const listSchemasAsync = createAppThunk<
+  {
+    data: Array<Schema>;
+  },
+  void
+>(
   'schemas/listSchemas',
-  async (params: {
-    projectName: string;
-  }): Promise<{
+  async (): Promise<{
     data: Array<Schema>;
   }> => {
-    const { projectName } = params;
-    const schemas = await listSchemas(projectName);
+    const schemas = await listSchemas();
     return { data: schemas };
   },
 );
@@ -91,22 +92,21 @@ export const listSchemasAsync = createAppThunk(
 export const getSchemasAsync = createAppThunk(
   'schemas/getSchemas',
   async (params: {
-    projectName: string;
     schemaName: string;
   }): Promise<{
     data: Array<Schema>;
   }> => {
-    const { projectName, schemaName } = params;
-    const schemas = await getSchemas(projectName, schemaName);
+    const { schemaName } = params;
+    const schemas = await getSchemas(schemaName);
     return { data: schemas };
   },
 );
 
 export const removeSchemaAsync = createAppThunk(
   'schemas/removeSchema',
-  async (params: { projectName: string; schemaName: string; version: number }): Promise<void> => {
-    const { projectName, schemaName, version } = params;
-    await removeSchema(projectName, schemaName, version);
+  async (params: { schemaName: string; version: number }): Promise<void> => {
+    const { schemaName, version } = params;
+    await removeSchema(schemaName, version);
   },
 );
 

--- a/src/features/users/usersSlice.ts
+++ b/src/features/users/usersSlice.ts
@@ -21,7 +21,7 @@ import { User, RPCStatusCode, RPCError } from 'api/types';
 import { RootState } from 'app/store';
 
 export interface UsersState {
-  isValidToken: boolean;
+  isAuthenticated: boolean;
   authProvider: string;
   username: string;
   fetchMe: {
@@ -93,7 +93,7 @@ export type ChangePasswordFields = {
 };
 
 const initialState: UsersState = {
-  isValidToken: false,
+  isAuthenticated: false,
   authProvider: '',
   username: '',
   fetchMe: {
@@ -165,8 +165,8 @@ export const usersSlice = createSlice({
   name: 'users',
   initialState,
   reducers: {
-    setIsValidToken: (state, action: PayloadAction<boolean>) => {
-      state.isValidToken = action.payload;
+    setIsAuthenticated: (state, action: PayloadAction<boolean>) => {
+      state.isAuthenticated = action.payload;
     },
     resetSignupState: (state) => {
       state.signup.isSuccess = false;
@@ -204,19 +204,22 @@ export const usersSlice = createSlice({
     },
   },
   extraReducers: (builder) => {
+    builder.addCase(fetchMe.pending, (state) => {
+      state.fetchMe.status = 'loading';
+    });
     builder.addCase(fetchMe.fulfilled, (state, action) => {
-      state.isValidToken = true;
+      state.isAuthenticated = true;
       state.username = action.payload.username;
       state.authProvider = action.payload.authProvider;
       state.fetchMe.status = 'idle';
     });
     builder.addCase(fetchMe.rejected, (state) => {
-      state.isValidToken = false;
+      state.isAuthenticated = false;
       state.username = '';
       state.fetchMe.status = 'failed';
     });
     builder.addCase(loginUser.fulfilled, (state, action) => {
-      state.isValidToken = true;
+      state.isAuthenticated = true;
       state.username = action.payload.username;
       state.login.status = 'idle';
       state.login.isSuccess = true;
@@ -242,7 +245,7 @@ export const usersSlice = createSlice({
     });
     builder.addCase(logoutUser.fulfilled, (state) => {
       state.logout.isSuccess = true;
-      state.isValidToken = false;
+      state.isAuthenticated = false;
       state.username = '';
       state.login.status = 'idle';
       state.login.isSuccess = false;
@@ -349,7 +352,7 @@ export const usersSlice = createSlice({
 });
 
 export const {
-  setIsValidToken,
+  setIsAuthenticated,
   resetSignupState,
   toggleUseSystemTheme,
   toggleUseDarkTheme,

--- a/src/pages/Header.tsx
+++ b/src/pages/Header.tsx
@@ -24,7 +24,7 @@ import { selectUsers } from 'features/users/usersSlice';
 import { Breadcrumb, Icon } from 'components';
 
 export function Header({ className }: { className?: string }) {
-  const { isValidToken } = useAppSelector(selectUsers);
+  const { isAuthenticated } = useAppSelector(selectUsers);
 
   return (
     <header className={`header ${className}`}>
@@ -36,7 +36,7 @@ export function Header({ className }: { className?: string }) {
             </a>
             <span className="blind">Yorkie</span>
           </h1>
-          {isValidToken && (
+          {isAuthenticated && (
             <>
               <Breadcrumb.Inner>
                 <Breadcrumb.Item as="link" href="/projects">
@@ -49,7 +49,7 @@ export function Header({ className }: { className?: string }) {
             </>
           )}
         </Breadcrumb>
-        {isValidToken && (
+        {isAuthenticated && (
           <nav className="util_box">
             <ul className="util_list">
               <li className="util_item">

--- a/src/pages/PrivateRoute.tsx
+++ b/src/pages/PrivateRoute.tsx
@@ -24,21 +24,21 @@ export function PrivateRoute() {
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
   const location = useLocation();
-  const { isValidToken, logout, fetchMe: fetchMeState } = useAppSelector(selectUsers);
+  const { isAuthenticated, logout, fetchMe: fetchMeState } = useAppSelector(selectUsers);
 
   useEffect(() => {
     if (logout.isSuccess) {
       window.location.href = `${import.meta.env.VITE_SERVICE_URL}`;
+      return;
     }
 
-    if (!isValidToken) {
-      if (fetchMeState.status === 'idle') {
-        dispatch(fetchMe());
-      } else if (fetchMeState.status === 'failed') {
-        navigate('/login', { state: { from: location.pathname } });
-      }
+    // Only try to fetch user info if token is invalid and we're not already loading/processing
+    if (!isAuthenticated && fetchMeState.status === 'idle') {
+      dispatch(fetchMe());
+    } else if (!isAuthenticated && fetchMeState.status === 'failed') {
+      navigate('/login', { state: { from: location.pathname } });
     }
-  }, [dispatch, navigate, location, isValidToken, logout, fetchMeState]);
+  }, [dispatch, navigate, location, isAuthenticated, logout.isSuccess, fetchMeState.status]);
 
   return <Outlet />;
 }

--- a/src/pages/PublicRoute.tsx
+++ b/src/pages/PublicRoute.tsx
@@ -23,16 +23,19 @@ import { fetchMe, selectUsers } from 'features/users/usersSlice';
 export function PublicRoute() {
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
-  const { isValidToken } = useAppSelector(selectUsers);
+  const { isAuthenticated, fetchMe: fetchMeState } = useAppSelector(selectUsers);
 
   useEffect(() => {
-    if (isValidToken) {
+    if (isAuthenticated) {
       navigate('/projects');
       return;
     }
 
-    dispatch(fetchMe());
-  }, [isValidToken, navigate]);
+    // Only fetch if not already loading, failed, or processing
+    if (fetchMeState.status === 'idle') {
+      dispatch(fetchMe());
+    }
+  }, [isAuthenticated, navigate, fetchMeState.status, dispatch]);
 
   return <Outlet />;
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Reflect recent AdminAPI changes to dashboard

- Removed projectName parameter from various document-related actions and components, simplifying the API calls.
- Refactored user authentication state management, changing `isValidToken` to `isAuthenticated` for clarity.
- Adjusted project stats fetching logic to prevent unnecessary API calls.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Related to https://github.com/yorkie-team/yorkie/pull/1471

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added ability to rotate project API keys.
  - Added a “current project” selection to streamline admin actions and data access.

- Improvements
  - Simplified document and schema workflows to rely on the current project (fewer inputs).
  - Reduced redundant network requests across projects, stats, documents, and schemas.
  - Improved authentication handling and more consistent route access based on login state.

- Documentation
  - Minor clarification in login docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->