### PR TITLE
Display presences in DocumentDetail

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import './assets/styles/style.scss';
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -190,8 +190,18 @@ export async function listDocuments(
 
 // getDocument fetches a document of the given ID from the admin server.
 export async function getDocument(documentKey: string): Promise<DocumentSummary> {
-  const res = await client.getDocument({ documentKey });
-  return converter.fromDocumentSummary(res.document!);
+  // Use getDocuments API with include_presences to get presence information
+  const res = await client.getDocuments({
+    documentKeys: [documentKey],
+    includeRoot: true,
+    includePresences: true,
+  });
+
+  if (!res.documents || res.documents.length === 0) {
+    throw new RPCError(String(RPCStatusCode.NOT_FOUND), 'Document not found');
+  }
+
+  return converter.fromDocumentSummary(res.documents[0]);
 }
 
 // searchDocuments fetches documents that match the query parameters.

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -14,10 +14,15 @@
  * limitations under the License.
  */
 
+export type Presence = {
+  [key: string]: string;
+};
+
 export type DocumentSummary = {
   id: string;
   key: string;
   root: string;
+  presences?: { [key: string]: Presence };
   attachedClients: number;
   docSize?: DocSize;
   createdAt: number;
@@ -102,8 +107,7 @@ export type AuthWebhookMethod =
   | 'WatchDocuments'
   | 'Broadcast';
 
-export type EventWebhookEvent =
-  | 'DocumentRootChanged';
+export type EventWebhookEvent = 'DocumentRootChanged';
 
 export const AUTH_WEBHOOK_METHODS: Array<AuthWebhookMethod> = [
   'ActivateClient',
@@ -115,9 +119,7 @@ export const AUTH_WEBHOOK_METHODS: Array<AuthWebhookMethod> = [
   'Broadcast',
 ];
 
-export const EVENT_WEBHOOK_EVENTS: Array<EventWebhookEvent> = [
-  'DocumentRootChanged',
-];
+export const EVENT_WEBHOOK_EVENTS: Array<EventWebhookEvent> = ['DocumentRootChanged'];
 
 export enum RPCStatusCode {
   OK = 0,

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactNode } from 'react';
+import { forwardRef, ReactNode } from 'react';
 import { Link } from 'react-router-dom';
 
 export function Breadcrumb({ children }: { children: ReactNode }) {
@@ -25,7 +25,7 @@ function Inner({ children }: { children: ReactNode }) {
   return <div className="breadcrumb_inner">{children}</div>;
 }
 
-const Item = React.forwardRef(
+const Item = forwardRef(
   (
     {
       as = 'button',

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { forwardRef, ReactNode, AnchorHTMLAttributes, ButtonHTMLAttributes } from 'react';
+import { forwardRef, ReactNode, AnchorHTMLAttributes, ButtonHTMLAttributes } from 'react';
 import { Link } from 'react-router-dom';
 import classNames from 'classnames';
 import { ButtonBox } from './ButtonBox';

--- a/src/components/Button/ButtonBox.tsx
+++ b/src/components/Button/ButtonBox.tsx
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import React, { ReactNode } from 'react';
+import { ReactNode, forwardRef } from 'react';
 import classNames from 'classnames';
 
-export const ButtonBox = React.forwardRef<
+export const ButtonBox = forwardRef<
   HTMLDivElement,
   {
     fullWidth?: boolean;

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactNode } from 'react';
+import { forwardRef, ReactNode } from 'react';
 import { Link } from 'react-router-dom';
 import classNames from 'classnames';
 
@@ -28,7 +28,7 @@ type DropdownProps = {
 };
 type DropdownRef = HTMLDivElement;
 
-export const Dropdown = React.forwardRef<DropdownRef, DropdownProps>(({ children, large, shadow, className }, ref) => {
+export const Dropdown = forwardRef<DropdownRef, DropdownProps>(({ children, large, shadow, className }, ref) => {
   const shadowClass = shadow ? `shadow_${shadow}` : '';
 
   return (

--- a/src/components/Input/InputHelperText.tsx
+++ b/src/components/Input/InputHelperText.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { Icon } from 'components';
 
 export function InputHelperText({

--- a/src/components/Input/InputTextBox.tsx
+++ b/src/components/Input/InputTextBox.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactNode, InputHTMLAttributes } from 'react';
+import { ReactNode, InputHTMLAttributes, forwardRef } from 'react';
 import classNames from 'classnames';
 import { InputHelperText } from './InputHelperText';
 
@@ -31,7 +31,7 @@ type InputTextBoxProps = {
   fullWidth?: boolean;
 } & InputHTMLAttributes<HTMLInputElement>;
 
-export const InputTextBox = React.forwardRef((props: InputTextBoxProps, ref) => {
+export const InputTextBox = forwardRef((props: InputTextBoxProps, ref) => {
   return <InputTextBoxInner {...props} inputRef={ref} />;
 });
 InputTextBox.displayName = 'InputTextBox';

--- a/src/components/Input/InputTextField.tsx
+++ b/src/components/Input/InputTextField.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useCallback, useRef, useState } from 'react';
+import { forwardRef, useCallback, useRef, useState } from 'react';
 import classNames from 'classnames';
 import { Icon, Button, InputHelperText } from 'components';
 import { useOutsideClick, useAreaBlur } from 'hooks';
@@ -35,7 +35,7 @@ type InputTextFieldProps = {
   onSuccessEnd?: () => void;
 } & React.InputHTMLAttributes<HTMLInputElement>;
 
-export const InputTextField = React.forwardRef<HTMLInputElement, InputTextFieldProps>(
+export const InputTextField = forwardRef<HTMLInputElement, InputTextFieldProps>(
   (
     {
       type = 'text',

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { Icon } from 'components';
 import classNames from 'classnames';
 

--- a/src/components/Navigator/Navigator.tsx
+++ b/src/components/Navigator/Navigator.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import classNames from 'classnames';
 
 export const Navigator = ({ navList }: { navList: Array<{ name: string; id: string }> }) => {

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactNode, useRef } from 'react';
+import { ReactNode, useRef } from 'react';
 import { useUncontrolled, useOutsideClick } from 'hooks';
 import { PopoverContextProvider } from './Popover.context';
 import { PopoverTarget } from './PopoverTarget';

--- a/src/components/Popover/PopoverDropdown.tsx
+++ b/src/components/Popover/PopoverDropdown.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { cloneElement } from 'react';
+import { cloneElement } from 'react';
 import { isElement } from 'utils';
 import { usePopoverContext } from './Popover.context';
 

--- a/src/components/Popover/PopoverTarget.tsx
+++ b/src/components/Popover/PopoverTarget.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { cloneElement } from 'react';
+import { cloneElement } from 'react';
 import { isElement } from 'utils';
 import { usePopoverContext } from './Popover.context';
 

--- a/src/components/TabList/TabList.tsx
+++ b/src/components/TabList/TabList.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 import { NavLink as Link } from 'react-router-dom';
 import classNames from 'classnames';
 

--- a/src/features/documents/DocumentDetail.tsx
+++ b/src/features/documents/DocumentDetail.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { fromUnixTime, format } from 'date-fns';
 import { Link, useParams, useNavigate } from 'react-router-dom';
 import { useAppDispatch, useAppSelector } from 'app/hooks';
@@ -34,18 +34,14 @@ export function DocumentDetail() {
   const documentKey = params.documentKey || '';
   const documentJSON = document ? JSON.parse(document.root) : {};
   const documentJSONStr = JSON.stringify(documentJSON, null, '\t');
-  const [viewType, SetViewType] = useState('code');
+  const [showContent, setShowContent] = useState<'root' | 'presence'>('root');
   const [opened, setOpened] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   useEffect(() => {
     if (!currentProject || !documentKey) return;
 
-    dispatch(
-      getDocumentAsync({
-        documentKey,
-      }),
-    );
+    dispatch(getDocumentAsync({ documentKey }));
   }, [dispatch, currentProject, documentKey]);
 
   if (!document) {
@@ -117,16 +113,16 @@ export function DocumentDetail() {
           </div>
           <div className="box_right">
             <Button
-              icon={<Icon type="codeSnippet" />}
-              color="toggle"
-              onClick={() => SetViewType('code')}
-              className={viewType === 'code' ? 'is_active' : ''}
-            />
-            <Button
               icon={<Icon type="branch" />}
               color="toggle"
-              onClick={() => SetViewType('tree')}
-              className={viewType === 'tree' ? 'is_active' : ''}
+              onClick={() => setShowContent('root')}
+              className={showContent === 'root' ? 'is_active' : ''}
+            />
+            <Button
+              icon={<Icon type="addMember" />}
+              color="toggle"
+              onClick={() => setShowContent('presence')}
+              className={showContent === 'presence' ? 'is_active' : ''}
             />
             <div className="btn_area">
               <CopyButton value={document?.root || ''} timeout={1000}>
@@ -145,14 +141,18 @@ export function DocumentDetail() {
             </div>
           </div>
         </div>
-        {viewType === 'code' && (
+        {showContent === 'root' && (
           <div className="codeblock">
             <CodeBlock.Code code={documentJSONStr} language="json" withLineNumbers />
           </div>
         )}
-        {viewType === 'tree' && (
-          <div className="codeblock_tree_box">
-            <CodeBlock.Tree code={documentJSON} />
+        {showContent === 'presence' && (
+          <div className="codeblock">
+            <CodeBlock.Code
+              code={JSON.stringify(document.presences, null, '\t') || '{}'}
+              language="json"
+              withLineNumbers
+            />
           </div>
         )}
       </div>

--- a/src/features/documents/DocumentList.tsx
+++ b/src/features/documents/DocumentList.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { Link, useLocation, useParams, useNavigationType } from 'react-router-dom';
 import { fromUnixTime, format } from 'date-fns';
 import classNames from 'classnames';

--- a/src/features/globalError/ErrorModal.tsx
+++ b/src/features/globalError/ErrorModal.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { useAppDispatch, useAppSelector } from 'app/hooks';
 import { selectGlobalError, resetGlobalError } from './globalErrorSlice';
 import { Modal, Icon } from 'components';

--- a/src/features/projects/APIKeys.tsx
+++ b/src/features/projects/APIKeys.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { useAppSelector } from 'app/hooks';
 import { selectProjectDetail } from './projectsSlice';

--- a/src/features/projects/Overview.tsx
+++ b/src/features/projects/Overview.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useAppSelector, useAppDispatch } from 'app/hooks';
 import {
   getProjectStatsAsync,

--- a/src/features/projects/ProjectDropdown.tsx
+++ b/src/features/projects/ProjectDropdown.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
 
 import { useAppDispatch, useAppSelector } from 'app/hooks';

--- a/src/features/projects/ProjectList.tsx
+++ b/src/features/projects/ProjectList.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import { fromUnixTime, format } from 'date-fns';
 import classNames from 'classnames';

--- a/src/features/projects/ProjectTabList.tsx
+++ b/src/features/projects/ProjectTabList.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { useAppDispatch, useAppSelector } from 'app/hooks';
 import { getProjectAsync, setCurrentProjectAsync, selectCurrentProject, selectProjectDetail } from './projectsSlice';

--- a/src/features/projects/QuickStart.tsx
+++ b/src/features/projects/QuickStart.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import classNames from 'classnames';
 import { useAppSelector } from 'app/hooks';
 import { selectProjectDetail } from './projectsSlice';

--- a/src/features/projects/RegisterForm.tsx
+++ b/src/features/projects/RegisterForm.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useEffect, useCallback } from 'react';
+import { useEffect, useCallback } from 'react';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import { useAppDispatch, useAppSelector } from 'app/hooks';
@@ -39,9 +39,12 @@ export function RegisterForm() {
   const { isSuccess, error } = useAppSelector(selectProjectCreate);
   const { project } = useAppSelector(selectProjectDetail);
 
-  const onSubmit = useCallback((data: ProjectCreateFields) => {
-    dispatch(createProjectAsync(data));
-  }, [dispatch]);
+  const onSubmit = useCallback(
+    (data: ProjectCreateFields) => {
+      dispatch(createProjectAsync(data));
+    },
+    [dispatch],
+  );
 
   useEffect(() => {
     if (!error) return;
@@ -76,7 +79,9 @@ export function RegisterForm() {
           </div>
         </div>
         <Button.Box>
-          <Button type="submit" className="orange_0">Create</Button>
+          <Button type="submit" className="orange_0">
+            Create
+          </Button>
         </Button.Box>
       </fieldset>
     </form>

--- a/src/features/projects/Settings.tsx
+++ b/src/features/projects/Settings.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useForm, useController } from 'react-hook-form';
 import classNames from 'classnames';

--- a/src/features/schemas/SchemaDetail.tsx
+++ b/src/features/schemas/SchemaDetail.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Link, useNavigate, useParams, useLocation } from 'react-router-dom';
 import CodeMirror from '@uiw/react-codemirror';
 import { javascript } from '@codemirror/lang-javascript';

--- a/src/features/schemas/SchemaList.tsx
+++ b/src/features/schemas/SchemaList.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { Link, useLocation, useParams } from 'react-router-dom';
 import { fromUnixTime, format } from 'date-fns';
 import classNames from 'classnames';

--- a/src/features/users/Account.tsx
+++ b/src/features/users/Account.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useCallback, useState, useEffect } from 'react';
+import { useCallback, useState, useEffect } from 'react';
 import { Button, Icon, Modal, InputTextBox } from 'components';
 import { selectUsers, ChangePasswordFields, changePassword, logoutUser } from './usersSlice';
 import { useAppDispatch, useAppSelector } from 'app/hooks';

--- a/src/features/users/AccountDropdown.tsx
+++ b/src/features/users/AccountDropdown.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useCallback, useState, useEffect } from 'react';
+import { useCallback, useState, useEffect } from 'react';
 import { useAppSelector, useAppDispatch } from 'app/hooks';
 import { selectUsers, logoutUser } from './usersSlice';
 import { Popover, Dropdown } from 'components';

--- a/src/features/users/DangerZone.tsx
+++ b/src/features/users/DangerZone.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { Button, Icon, Modal, InputTextBox } from 'components';
 import { deleteUser, logoutUser, selectUsers } from './usersSlice';
 import { useAppDispatch, useAppSelector } from 'app/hooks';

--- a/src/features/users/LoginForm.tsx
+++ b/src/features/users/LoginForm.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useEffect, useCallback } from 'react';
+import { useEffect, useCallback } from 'react';
 import { useForm } from 'react-hook-form';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useAppDispatch, useAppSelector } from 'app/hooks';

--- a/src/features/users/MobileGnbDropdown.tsx
+++ b/src/features/users/MobileGnbDropdown.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useCallback, useState, useEffect } from 'react';
+import { useCallback, useState, useEffect } from 'react';
 import classNames from 'classnames';
 import { useAppSelector, useAppDispatch } from 'app/hooks';
 import { selectUsers, logoutUser } from './usersSlice';

--- a/src/features/users/Preferences.tsx
+++ b/src/features/users/Preferences.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 import { InputToggle } from 'components';
 import { useAppDispatch, useAppSelector } from 'app/hooks';
 import { selectPreferences, toggleUseSystemTheme, toggleUseDarkTheme, toggleUse24HourClock } from './usersSlice';

--- a/src/features/users/SignupForm.tsx
+++ b/src/features/users/SignupForm.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useEffect, useCallback } from 'react';
+import { useEffect, useCallback } from 'react';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import { SignupFields, selectUsers, signupUser, resetSignupState } from './usersSlice';

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { LoginForm } from 'features/users';
 import { PageTemplate } from './PageTemplate';
 import { Icon, Button } from 'components';

--- a/src/pages/PageTemplate.tsx
+++ b/src/pages/PageTemplate.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 
 import { Header } from './Header';
 import { Footer } from './Footer';

--- a/src/pages/PrivateRoute.tsx
+++ b/src/pages/PrivateRoute.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { Outlet, useNavigate, useLocation } from 'react-router-dom';
 
 import { useAppSelector, useAppDispatch } from 'app/hooks';

--- a/src/pages/ProjectPageTemplate.tsx
+++ b/src/pages/ProjectPageTemplate.tsx
@@ -14,14 +14,11 @@
  * limitations under the License.
  */
 
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 import { ProjectTabList, ProjectDropdown } from 'features/projects';
 import { PageTemplate } from './PageTemplate';
 
-export function ProjectPageTemplate({ className, children }: {
-  className: string;
-  children: ReactNode;
-}) {
+export function ProjectPageTemplate({ className, children }: { className: string; children: ReactNode }) {
   return (
     <PageTemplate className={className}>
       <div className="box_top">

--- a/src/pages/ProjectsPage.tsx
+++ b/src/pages/ProjectsPage.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { ProjectList } from 'features/projects';
 import BannerSVG from 'assets/images/@tmp/sample_banner_icon.svg?react';
 import { Button, Icon } from 'components';

--- a/src/pages/PublicRoute.tsx
+++ b/src/pages/PublicRoute.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { Outlet, useNavigate, useLocation } from 'react-router-dom';
 
 import { useAppDispatch, useAppSelector } from 'app/hooks';

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { PageTemplate } from './PageTemplate';
 import { Button, Icon, Navigator } from 'components';

--- a/src/test/ModalView.tsx
+++ b/src/test/ModalView.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Modal, Icon, Button, Popover } from 'components';
 
 export function ModalView() {

--- a/src/utils/create-safe-context.tsx
+++ b/src/utils/create-safe-context.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext } from 'react';
+import { createContext, useContext } from 'react';
 
 export function createSafeContext<ContextValue>(errorMessage: string) {
   const Context = createContext<ContextValue | null>(null);


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Display presences in DocumentDetail

This commit introduces a new feature in the Document Detail page that
allows toggling between the Root view and the Presence view, with
presence data shown as JSON when available.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Document Detail: Toggle between Root and Presence views.
  - Presence data is now displayed as JSON when available.
- Bug Fixes
  - Clearer error shown when a document is not found.
- Refactor
  - Modernized React usage across the app (removed default React import, adopted direct forwardRef); no functional changes.
- Chores
  - General code cleanup for consistency with modern JSX runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->