### PR TITLE
feat(settings): enforce read-only project config for Member role

### DIFF
--- a/src/assets/styles/pages/admin_setting_project.scss
+++ b/src/assets/styles/pages/admin_setting_project.scss
@@ -53,6 +53,51 @@
     }
   }
 
+  // Read-only notice shown to Members, who cannot edit the project config.
+  .setting_readonly_notice {
+    display: flex;
+    align-items: center;
+    gap: variables.$spacing_8;
+    margin-top: variables.$spacing_24;
+    padding: variables.$spacing_16;
+    border: 1px solid var(--gray-300);
+    border-radius: 8px;
+    background: var(--gray-100);
+    color: var(--gray-700);
+
+    svg {
+      flex-shrink: 0;
+    }
+
+    p {
+      margin: 0;
+      font-size: 1.3rem;
+      line-height: 1.5;
+    }
+  }
+
+  // Wraps the whole project-config form so a single `disabled` attribute puts
+  // every control into read-only mode for Members.
+  .setting_form_fieldset {
+    min-inline-size: 0;
+    margin: 0;
+    padding: 0;
+    border: 0;
+
+    &:disabled {
+      .input {
+        border-color: var(--gray-300);
+        color: var(--gray-300);
+        -webkit-text-fill-color: var(--gray-300);
+        cursor: not-allowed;
+
+        &::placeholder {
+          color: var(--gray-300);
+        }
+      }
+    }
+  }
+
   .setting {
     $set: '.setting';
 

--- a/src/assets/styles/pages/admin_setting_project.scss
+++ b/src/assets/styles/pages/admin_setting_project.scss
@@ -76,8 +76,7 @@
     }
   }
 
-  // Wraps the whole project-config form so a single `disabled` attribute puts
-  // every control into read-only mode for Members.
+  // A single `disabled` on the fieldset puts every control into read-only mode.
   .setting_form_fieldset {
     min-inline-size: 0;
     margin: 0;
@@ -87,8 +86,9 @@
     &:disabled {
       .input {
         border-color: var(--gray-300);
-        color: var(--gray-300);
-        -webkit-text-fill-color: var(--gray-300);
+        // Keep values readable in read-only mode (not just a faint disabled grey).
+        color: var(--gray-600);
+        -webkit-text-fill-color: var(--gray-600);
         cursor: not-allowed;
 
         &::placeholder {

--- a/src/assets/styles/pages/admin_setting_project.scss
+++ b/src/assets/styles/pages/admin_setting_project.scss
@@ -86,6 +86,7 @@
     &:disabled {
       .input {
         border-color: var(--gray-300);
+
         // Keep values readable in read-only mode (not just a faint disabled grey).
         color: var(--gray-600);
         -webkit-text-fill-color: var(--gray-600);

--- a/src/features/members/membersSlice.ts
+++ b/src/features/members/membersSlice.ts
@@ -222,6 +222,17 @@ export const membersSlice = createSlice({
 export const { resetCreateInviteStatus, resetAcceptInviteStatus } = membersSlice.actions;
 
 export const selectMembersList = (state: RootState) => state.members.list;
+
+// selectCurrentMemberRole returns the current user's normalized role in the
+// active project ('owner' | 'admin' | 'member'), or '' when it is not yet known
+// (e.g. the members list has not loaded). Callers should treat '' as no edit
+// permission so that access defaults to read-only until the role is resolved.
+export const selectCurrentMemberRole = (state: RootState): string => {
+  const username = state.users.isAuthenticated ? state.users.username : '';
+  if (!username) return '';
+  const me = state.members.list.members.find((member) => member.username === username);
+  return (me?.role || '').toLowerCase();
+};
 export const selectCreateInviteStatus = (state: RootState) => state.members.createInvite;
 export const selectAcceptInviteStatus = (state: RootState) => state.members.acceptInvite;
 export const selectRemoveStatus = (state: RootState) => state.members.remove;

--- a/src/features/members/membersSlice.ts
+++ b/src/features/members/membersSlice.ts
@@ -223,10 +223,7 @@ export const { resetCreateInviteStatus, resetAcceptInviteStatus } = membersSlice
 
 export const selectMembersList = (state: RootState) => state.members.list;
 
-// selectCurrentMemberRole returns the current user's normalized role in the
-// active project ('owner' | 'admin' | 'member'), or '' when it is not yet known
-// (e.g. the members list has not loaded). Callers should treat '' as no edit
-// permission so that access defaults to read-only until the role is resolved.
+// Current user's lowercased role in the active project, or '' if not yet resolved (treat as read-only).
 export const selectCurrentMemberRole = (state: RootState): string => {
   const username = state.users.isAuthenticated ? state.users.username : '';
   if (!username) return '';

--- a/src/features/projects/Settings.tsx
+++ b/src/features/projects/Settings.tsx
@@ -34,8 +34,9 @@ import {
   AuthWebhookMethod,
   EventWebhookEvent,
 } from 'api/types';
-import { InputToggle, InputHelperText, InputTextField, Navigator } from 'components';
+import { Icon, InputToggle, InputHelperText, InputTextField, Navigator } from 'components';
 import { MembersList } from 'features/members';
+import { selectCurrentMemberRole } from 'features/members/membersSlice';
 
 export type UpdateFieldInfo = {
   target: keyof UpdatableProjectFields | AuthWebhookMethod | EventWebhookEvent | null;
@@ -47,6 +48,15 @@ export function Settings() {
   const dispatch = useAppDispatch();
   const { project } = useAppSelector(selectProjectDetail);
   const { isSuccess, error } = useAppSelector(selectProjectUpdate);
+  // Project config is editable only by Owners and Admins. Members get a
+  // read-only view. The role is resolved from the members list (loaded by the
+  // <MembersList /> below); until it is known we default to read-only so that
+  // access never briefly opens up for a Member. The Admin API enforces the same
+  // rule, so this only gates the UI. See yorkie-team/yorkie feat/update-project-rbac.
+  const currentMemberRole = useAppSelector(selectCurrentMemberRole);
+  const canEditConfig = currentMemberRole === 'owner' || currentMemberRole === 'admin';
+  const isReadOnly = !canEditConfig;
+  const isMember = currentMemberRole === 'member';
   const [updateFieldInfo, setUpdateFieldInfo] = useState<UpdateFieldInfo>({ target: null, state: null, message: '' });
   const {
     register,
@@ -168,6 +178,11 @@ export function Settings() {
 
   const onSubmit = useCallback(
     (fields: Partial<ProjectUpdateFields>) => {
+      // Guard against edits from users without permission (e.g. Members). The
+      // fields are disabled in the UI, but this keeps the client honest even if
+      // a control is triggered programmatically. The server enforces this too.
+      if (!canEditConfig) return;
+
       const updateFields: Partial<ProjectUpdateFields> = {};
       Object.entries(fields).forEach((field) => {
         const [key, value] = field as [keyof UpdatableProjectFields, any];
@@ -181,7 +196,7 @@ export function Settings() {
         }),
       );
     },
-    [dispatch, project?.id],
+    [dispatch, project?.id, canEditConfig],
   );
 
   useEffect(() => {
@@ -277,856 +292,868 @@ export function Settings() {
         ]}
       />
       <div className="box_right">
+        {isMember && (
+          <div className="setting_readonly_notice" role="note">
+            <Icon type="lockSmall" />
+            <p>
+              You have read-only access to these settings. Only <strong>Owners</strong> and <strong>Admins</strong> can
+              update the project configuration.
+            </p>
+          </div>
+        )}
         <form onSubmit={handleSubmit(onSubmit)}>
-          <div className="section setting_box" id="general">
-            <div className="setting_title">
-              <strong className="text">General</strong>
-            </div>
-            <dl className="sub_info">
-              <dt className="sub_title">Project name</dt>
-              <dd className="sub_desc">
-                <div
-                  className={classNames('input_field_box', {
-                    is_error: checkFieldState('name', 'error'),
-                    is_success: checkFieldState('name', 'success'),
-                  })}
-                >
-                  <InputTextField
-                    reset={() => {
-                      resetForm();
-                      resetUpdateFieldInfo();
-                    }}
-                    {...register('name', {
-                      required: 'The project name is required',
-                      pattern: {
-                        value: /^[a-zA-Z0-9\-._~]{2,30}$/,
-                        message:
-                          'Project name should only contain 2 to 30 characters with alphabets, numbers, hyphen(-), period(.), underscore(_), and tilde(~)',
-                      },
-                      onChange: async () => {
-                        await trigger('name');
-                      },
+          <fieldset className="setting_form_fieldset" disabled={isReadOnly}>
+            <div className="section setting_box" id="general">
+              <div className="setting_title">
+                <strong className="text">General</strong>
+              </div>
+              <dl className="sub_info">
+                <dt className="sub_title">Project name</dt>
+                <dd className="sub_desc">
+                  <div
+                    className={classNames('input_field_box', {
+                      is_error: checkFieldState('name', 'error'),
+                      is_success: checkFieldState('name', 'success'),
                     })}
-                    onChange={(e) => {
-                      setUpdateFieldInfo((info) => ({ ...info, target: 'name' }));
-                      nameField.onChange(e.target.value);
-                    }}
-                    id="name"
-                    label="Project name"
-                    blindLabel={true}
-                    fieldUtil={true}
-                    state={
-                      checkFieldState('name', 'success')
-                        ? 'success'
-                        : checkFieldState('name', 'error')
-                          ? 'error'
-                          : undefined
-                    }
-                    helperText={
-                      updateFieldInfo.target === 'name' && updateFieldInfo.state !== null
-                        ? updateFieldInfo.message
-                        : undefined
-                    }
-                    onSuccessEnd={resetUpdateFieldInfo}
-                  />
-                </div>
-              </dd>
-              <dt className="sub_title">Members</dt>
-              <dd className="sub_desc">
-                <p className="guide">
-                  Manage project members and their roles. Members can collaborate on documents and access project
-                  resources based on their assigned roles.
-                </p>
-                <MembersList />
-              </dd>
-            </dl>
-          </div>
-          <div className="section setting_box webhook" id="webhooks">
-            <div className="setting_title">
-              <strong className="text">Webhooks</strong>
-            </div>
-            <dl className="sub_info">
-              <dt className="sub_title">Webhook URL</dt>
-              <dd className="sub_desc">
-                <p className="guide">
-                  Set the webhook URL for event notifications. When enabled events occur (e.g., document content
-                  changes), Yorkie sends a POST request to this endpoint with event details. Use this for integrations,
-                  notifications, or syncing with external systems. Changes may take up to 10 minutes to take effect.{' '}
-                  <a
-                    href="https://yorkie.dev/docs/advanced/event-webhook"
-                    className="page_link icon_link"
-                    target="_blank"
-                    rel="noreferrer"
                   >
-                    Learn more about Event Webhook.
-                  </a>
-                </p>
-                <div
-                  className={classNames('input_field_box', {
-                    is_error: checkFieldState('eventWebhookURL', 'error'),
-                    is_success: checkFieldState('eventWebhookURL', 'success'),
-                  })}
-                >
-                  <InputTextField
-                    reset={() => {
-                      resetForm();
-                      resetUpdateFieldInfo();
-                    }}
-                    {...register('eventWebhookURL')}
-                    onChange={(e) => {
-                      setUpdateFieldInfo((info) => ({ ...info, target: 'eventWebhookURL' }));
-                      eventWebhookURLField.onChange(e.target.value);
-                    }}
-                    id="eventWebhookURL"
-                    label="eventWebhookURL"
-                    blindLabel={true}
-                    placeholder="http://localhost:8080/event"
-                    fieldUtil={true}
-                    state={
-                      checkFieldState('eventWebhookURL', 'success')
-                        ? 'success'
-                        : checkFieldState('eventWebhookURL', 'error')
-                          ? 'error'
+                    <InputTextField
+                      reset={() => {
+                        resetForm();
+                        resetUpdateFieldInfo();
+                      }}
+                      {...register('name', {
+                        required: 'The project name is required',
+                        pattern: {
+                          value: /^[a-zA-Z0-9\-._~]{2,30}$/,
+                          message:
+                            'Project name should only contain 2 to 30 characters with alphabets, numbers, hyphen(-), period(.), underscore(_), and tilde(~)',
+                        },
+                        onChange: async () => {
+                          await trigger('name');
+                        },
+                      })}
+                      onChange={(e) => {
+                        setUpdateFieldInfo((info) => ({ ...info, target: 'name' }));
+                        nameField.onChange(e.target.value);
+                      }}
+                      id="name"
+                      label="Project name"
+                      blindLabel={true}
+                      fieldUtil={true}
+                      state={
+                        checkFieldState('name', 'success')
+                          ? 'success'
+                          : checkFieldState('name', 'error')
+                            ? 'error'
+                            : undefined
+                      }
+                      helperText={
+                        updateFieldInfo.target === 'name' && updateFieldInfo.state !== null
+                          ? updateFieldInfo.message
                           : undefined
-                    }
-                    helperText={
-                      updateFieldInfo.target === 'eventWebhookURL' && updateFieldInfo.state !== null
-                        ? updateFieldInfo.message
-                        : undefined
-                    }
-                    onSuccessEnd={resetUpdateFieldInfo}
-                  />
-                </div>
-              </dd>
-              <dt className="sub_title">Webhook Events</dt>
-              <dd className="sub_desc">
-                <p className="guide">
-                  Select which events require webhook event. Only the selected events will be checked for event.
-                </p>
-                <div className="webhook_events">
-                  {EVENT_WEBHOOK_EVENTS.map((event) => {
-                    return (
-                      <div
-                        className={classNames('input_group', {
-                          is_error: checkFieldState(event, 'error'),
-                          is_success: checkFieldState(event, 'success'),
-                        })}
-                        key={event}
-                      >
-                        <InputToggle
-                          id={event}
-                          label={event}
-                          checked={webhookEventField.value.includes(event)}
-                          onChange={(e) => {
-                            let newWebhookEvents = [...project?.eventWebhookEvents!];
-                            if (e.target.checked) {
-                              newWebhookEvents = newWebhookEvents.includes(event)
-                                ? newWebhookEvents
-                                : [...newWebhookEvents, event];
-                            } else {
-                              newWebhookEvents = newWebhookEvents.filter((newEvent) => newEvent !== event);
-                            }
-                            webhookEventField.onChange(newWebhookEvents);
-                            setUpdateFieldInfo((info) => ({ ...info, target: event }));
-                            onSubmit({ eventWebhookEvents: newWebhookEvents });
-                          }}
-                        />
-                        {updateFieldInfo.target === event && updateFieldInfo.state !== null && (
-                          <InputHelperText
-                            state={updateFieldInfo.state}
-                            message={updateFieldInfo.message}
-                            onSuccessEnd={resetUpdateFieldInfo}
-                          />
-                        )}
-                      </div>
-                    );
-                  })}
-                </div>
-              </dd>
-            </dl>
-          </div>
-          <div className="section setting_box webhook" id="security">
-            <div className="setting_title">
-              <strong className="text">Security</strong>
-            </div>
-            <dl className="sub_info">
-              <dt className="sub_title">Allowed Origins</dt>
-              <dd className="sub_desc">
-                <p className="guide">
-                  Configure CORS (Cross-Origin Resource Sharing) by specifying which origins can connect to the Yorkie
-                  server. Use the wildcard character * to allow all origins, or specify individual origins separated by
-                  commas. Changes to this setting may take up to 10 minutes to take effect.{' '}
-                  <a
-                    href="https://yorkie.dev/docs/advanced/security#allowed-origins"
-                    className="page_link icon_link"
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    Learn more about Allowed Origins.
-                  </a>
-                </p>
-                <div className="input_field_box">
-                  <InputTextField
-                    reset={() => {
-                      resetForm();
-                      resetUpdateFieldInfo();
-                    }}
-                    {...register('allowedOrigins', {
-                      validate: (value: string) => {
-                        if (!value) return true;
-                        const origins = value.split(',').map((origin) => origin.trim());
-                        const validOriginPattern = /^(\*|https?:\/\/[a-zA-Z0-9\-._~:/?#\[\]@!$&'()*+,;=]+)$/;
-                        return (
-                          origins.every((origin) => validOriginPattern.test(origin)) ||
-                          'Invalid origin format. Use valid URLs or * separated by commas'
-                        );
-                      },
-                    })}
-                    onChange={(e) => {
-                      setUpdateFieldInfo((info) => ({ ...info, target: 'allowedOrigins' }));
-                      allowedOrigins.onChange(e);
-                    }}
-                    onBlur={(e) => {
-                      // Normalize input by removing whitespace around commas
-                      const normalizedValue = e.target.value
-                        .split(',')
-                        .map((origin) => origin.trim())
-                        .filter((origin) => origin)
-                        .join(',');
-                      e.target.value = normalizedValue;
-                      allowedOrigins.onBlur();
-                    }}
-                    id="allowedOrigins"
-                    label="allowedOrigins"
-                    blindLabel={true}
-                    fieldUtil={true}
-                    placeholder="*, http://localhost:3000"
-                    state={
-                      checkFieldState('allowedOrigins', 'success')
-                        ? 'success'
-                        : checkFieldState('allowedOrigins', 'error')
-                          ? 'error'
-                          : undefined
-                    }
-                    helperText={
-                      updateFieldInfo.target === 'allowedOrigins' && updateFieldInfo.state !== null
-                        ? updateFieldInfo.message
-                        : undefined
-                    }
-                    onSuccessEnd={resetUpdateFieldInfo}
-                  />
-                </div>
-              </dd>
-              <dt className="sub_title">Auth Webhook URL</dt>
-              <dd className="sub_desc">
-                <p className="guide">
-                  Set the webhook URL for client authorization. When configured, Yorkie validates each client request by
-                  calling this endpoint with the client&apos;s token and requested action. Your server can then allow or
-                  deny access based on your custom authorization logic. Changes may take up to 10 minutes to take
-                  effect.{' '}
-                  <a
-                    href="https://yorkie.dev/docs/advanced/security#auth-webhook"
-                    className="page_link icon_link"
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    Learn more about Auth Webhook.
-                  </a>
-                </p>
-                <div
-                  className={classNames('input_field_box', {
-                    is_error: checkFieldState('authWebhookURL', 'error'),
-                    is_success: checkFieldState('authWebhookURL', 'success'),
-                  })}
-                >
-                  <InputTextField
-                    reset={() => {
-                      resetForm();
-                      resetUpdateFieldInfo();
-                    }}
-                    {...register('authWebhookURL')}
-                    onChange={(e) => {
-                      setUpdateFieldInfo((info) => ({ ...info, target: 'authWebhookURL' }));
-                      authWebhookURLField.onChange(e.target.value);
-                    }}
-                    id="authWebhookURL"
-                    label="authWebhookURL"
-                    blindLabel={true}
-                    placeholder="http://localhost:8080/auth"
-                    fieldUtil={true}
-                    state={
-                      checkFieldState('authWebhookURL', 'success')
-                        ? 'success'
-                        : checkFieldState('authWebhookURL', 'error')
-                          ? 'error'
-                          : undefined
-                    }
-                    helperText={
-                      updateFieldInfo.target === 'authWebhookURL' && updateFieldInfo.state !== null
-                        ? updateFieldInfo.message
-                        : undefined
-                    }
-                    onSuccessEnd={resetUpdateFieldInfo}
-                  />
-                </div>
-              </dd>
-              <dt className="sub_title">Auth Webhook Methods</dt>
-              <dd className="sub_desc">
-                <p className="guide">
-                  Select which methods require webhook authorization. Only the selected methods will be checked for
-                  authorization.
-                </p>
-                <div className="webhook_methods">
-                  {AUTH_WEBHOOK_METHODS.map((method) => {
-                    return (
-                      <div
-                        className={classNames('input_group', {
-                          is_error: checkFieldState(method, 'error'),
-                          is_success: checkFieldState(method, 'success'),
-                        })}
-                        key={method}
-                      >
-                        <InputToggle
-                          id={method}
-                          label={method}
-                          checked={webhookMethodField.value.includes(method)}
-                          onChange={(e) => {
-                            let newWebhookMethods = [...project?.authWebhookMethods!];
-                            if (e.target.checked) {
-                              newWebhookMethods = newWebhookMethods.includes(method)
-                                ? newWebhookMethods
-                                : [...newWebhookMethods, method];
-                            } else {
-                              newWebhookMethods = newWebhookMethods.filter((newMethod) => newMethod !== method);
-                            }
-                            webhookMethodField.onChange(newWebhookMethods);
-                            setUpdateFieldInfo((info) => ({ ...info, target: method }));
-                            onSubmit({ authWebhookMethods: newWebhookMethods });
-                          }}
-                        />
-                        {updateFieldInfo.target === method && updateFieldInfo.state !== null && (
-                          <InputHelperText
-                            state={updateFieldInfo.state}
-                            message={updateFieldInfo.message}
-                            onSuccessEnd={resetUpdateFieldInfo}
-                          />
-                        )}
-                      </div>
-                    );
-                  })}
-                </div>
-              </dd>
-            </dl>
-          </div>
-          <div className="section setting_box" id="resources">
-            <div className="setting_title">
-              <strong className="text">Resources</strong>
-            </div>
-            <dl className="sub_info">
-              <dt className="sub_title">Client Deactivate Threshold</dt>
-              <dd className="sub_desc">
-                <p className="guide">
-                  Set the duration after which inactive clients are automatically deactivated. This improves garbage
-                  collection efficiency by cleaning up stale client connections. Format: &quot;24h0m0s&quot; for 24
-                  hours, &quot;1h30m&quot; for 1 hour 30 minutes.{' '}
-                  <a
-                    href="https://yorkie.dev/docs/advanced/resources#clientdeactivatethreshold"
-                    className="page_link icon_link"
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    Learn more about Client Deactivate Threshold.
-                  </a>
-                </p>
-                <div
-                  className={classNames('input_field_box', {
-                    is_error: checkFieldState('clientDeactivateThreshold', 'error'),
-                    is_success: checkFieldState('clientDeactivateThreshold', 'success'),
-                  })}
-                >
-                  <InputTextField
-                    reset={() => {
-                      resetForm();
-                      resetUpdateFieldInfo();
-                    }}
-                    {...register('clientDeactivateThreshold', {
-                      required: 'Client Deactivate Threshold is required',
-                      pattern: {
-                        value: /^(\d{1,2}h\s?)?(\d{1,2}m\s?)?(\d{1,2}s)?$/,
-                        message:
-                          'Client Deactivate Threshold should be a signed sequence of decimal numbers, each with a unit suffix, such as "23h30m10s" or "2h45m"',
-                      },
-                      onChange: async () => {
-                        await trigger('clientDeactivateThreshold');
-                      },
-                    })}
-                    onChange={(e) => {
-                      setUpdateFieldInfo((info) => ({ ...info, target: 'clientDeactivateThreshold' }));
-                      clientDeactivateThreshold.onChange(e.target.value);
-                    }}
-                    id="clientDeactivateThreshold"
-                    label="clientDeactivateThreshold"
-                    blindLabel={true}
-                    fieldUtil={true}
-                    placeholder={'24h00m00s'}
-                    state={
-                      checkFieldState('clientDeactivateThreshold', 'success')
-                        ? 'success'
-                        : checkFieldState('clientDeactivateThreshold', 'error')
-                          ? 'error'
-                          : undefined
-                    }
-                    helperText={
-                      updateFieldInfo.target === 'clientDeactivateThreshold' && updateFieldInfo.state !== null
-                        ? updateFieldInfo.message
-                        : undefined
-                    }
-                    onSuccessEnd={resetUpdateFieldInfo}
-                  />
-                </div>
-              </dd>
-              <dt className="sub_title">Channel Session TTL</dt>
-              <dd className="sub_desc">
-                <p className="guide">
-                  Set how long a channel session is retained after a user leaves (1s–5m). Longer values keep users
-                  counted in presence longer after they disconnect, increasing the apparent live presence count.
-                  Format: &quot;15s&quot; for 15 seconds, &quot;1m30s&quot; for 1 minute 30 seconds.
-                </p>
-                <div
-                  className={classNames('input_field_box', {
-                    is_error: checkFieldState('channelSessionTtl', 'error'),
-                    is_success: checkFieldState('channelSessionTtl', 'success'),
-                  })}
-                >
-                  <InputTextField
-                    reset={() => {
-                      resetForm();
-                      resetUpdateFieldInfo();
-                    }}
-                    {...register('channelSessionTtl', {
-                      required: 'Channel Session TTL is required',
-                      pattern: {
-                        value: /^(\d{1,2}h\s?)?(\d{1,2}m\s?)?(\d{1,2}s)?$/,
-                        message: 'Channel Session TTL should be a duration string such as "15s" or "1m30s" (1s–5m)',
-                      },
-                      onChange: async () => {
-                        await trigger('channelSessionTtl');
-                      },
-                    })}
-                    onChange={(e) => {
-                      setUpdateFieldInfo((info) => ({ ...info, target: 'channelSessionTtl' }));
-                      channelSessionTtl.onChange(e.target.value);
-                    }}
-                    id="channelSessionTtl"
-                    label="channelSessionTtl"
-                    blindLabel={true}
-                    fieldUtil={true}
-                    placeholder={'15s'}
-                    state={
-                      checkFieldState('channelSessionTtl', 'success')
-                        ? 'success'
-                        : checkFieldState('channelSessionTtl', 'error')
-                          ? 'error'
-                          : undefined
-                    }
-                    helperText={
-                      updateFieldInfo.target === 'channelSessionTtl' && updateFieldInfo.state !== null
-                        ? updateFieldInfo.message
-                        : undefined
-                    }
-                    onSuccessEnd={resetUpdateFieldInfo}
-                  />
-                </div>
-              </dd>
-              <dt className="sub_title">Snapshot Threshold</dt>
-              <dd className="sub_desc">
-                <p className="guide">
-                  Set the number of changes that triggers snapshot delivery instead of individual changes. When a client
-                  needs to sync more changes than this threshold, the server sends a complete document snapshot for
-                  better performance. Default: 500.{' '}
-                  <a
-                    href="https://yorkie.dev/docs/advanced/resources#snapshotthreshold"
-                    className="page_link icon_link"
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    Learn more about Snapshot Threshold.
-                  </a>
-                </p>
-                <div
-                  className={classNames('input_field_box', {
-                    is_error: checkFieldState('snapshotThreshold', 'error'),
-                    is_success: checkFieldState('snapshotThreshold', 'success'),
-                  })}
-                >
-                  <InputTextField
-                    reset={() => {
-                      resetForm();
-                      resetUpdateFieldInfo();
-                    }}
-                    {...register('snapshotThreshold', {
-                      required: 'Snapshot Threshold is required',
-                      pattern: {
-                        value: /^[0-9]+$/,
-                        message: 'Snapshot Threshold must be a positive integer',
-                      },
-                      onChange: async () => {
-                        await trigger('snapshotThreshold');
-                      },
-                    })}
-                    onChange={(e) => {
-                      setUpdateFieldInfo((info) => ({ ...info, target: 'snapshotThreshold' }));
-                      snapshotThreshold.onChange(e.target.value);
-                    }}
-                    id="snapshotThreshold"
-                    label="Snapshot Threshold"
-                    blindLabel={true}
-                    fieldUtil={true}
-                    placeholder="0"
-                    state={
-                      checkFieldState('snapshotThreshold', 'success')
-                        ? 'success'
-                        : checkFieldState('snapshotThreshold', 'error')
-                          ? 'error'
-                          : undefined
-                    }
-                    helperText={
-                      updateFieldInfo.target === 'snapshotThreshold' && updateFieldInfo.state !== null
-                        ? updateFieldInfo.message
-                        : undefined
-                    }
-                    onSuccessEnd={resetUpdateFieldInfo}
-                  />
-                </div>
-              </dd>
-              <dt className="sub_title">Snapshot Interval</dt>
-              <dd className="sub_desc">
-                <p className="guide">
-                  Set the interval (in number of changes) at which the server creates and stores document snapshots.
-                  Lower values create snapshots more frequently, using more storage but improving sync performance for
-                  reconnecting clients. Default: 500.{' '}
-                  <a
-                    href="https://yorkie.dev/docs/advanced/resources#snapshotinterval"
-                    className="page_link icon_link"
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    Learn more about Snapshot Interval.
-                  </a>
-                </p>
-                <div
-                  className={classNames('input_field_box', {
-                    is_error: checkFieldState('snapshotInterval', 'error'),
-                    is_success: checkFieldState('snapshotInterval', 'success'),
-                  })}
-                >
-                  <InputTextField
-                    reset={() => {
-                      resetForm();
-                      resetUpdateFieldInfo();
-                    }}
-                    {...register('snapshotInterval', {
-                      required: 'Snapshot Interval is required',
-                      pattern: {
-                        value: /^[0-9]+$/,
-                        message: 'Snapshot Interval must be a positive integer',
-                      },
-                      onChange: async () => {
-                        await trigger('snapshotInterval');
-                      },
-                    })}
-                    onChange={(e) => {
-                      setUpdateFieldInfo((info) => ({ ...info, target: 'snapshotInterval' }));
-                      snapshotInterval.onChange(e.target.value);
-                    }}
-                    id="snapshotInterval"
-                    label="Snapshot Interval"
-                    blindLabel={true}
-                    fieldUtil={true}
-                    placeholder="0"
-                    state={
-                      checkFieldState('snapshotInterval', 'success')
-                        ? 'success'
-                        : checkFieldState('snapshotInterval', 'error')
-                          ? 'error'
-                          : undefined
-                    }
-                    helperText={
-                      updateFieldInfo.target === 'snapshotInterval' && updateFieldInfo.state !== null
-                        ? updateFieldInfo.message
-                        : undefined
-                    }
-                    onSuccessEnd={resetUpdateFieldInfo}
-                  />
-                </div>
-              </dd>
-
-              <dt className="sub_title">Max Attachments Per Document</dt>
-              <dd className="sub_desc">
-                <p className="guide">
-                  Limit the number of clients that can attach to a single document simultaneously. When exceeded, new
-                  attachment requests are rejected and must be manually retried. Set to 0 for unlimited. Use this to
-                  control resource usage in high-traffic scenarios.{' '}
-                  <a
-                    href="https://yorkie.dev/docs/advanced/resources#maxattachmentsperdocument"
-                    className="page_link icon_link"
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    Learn more about Max Attachments Per Document.
-                  </a>
-                </p>
-                <div
-                  className={classNames('input_field_box', {
-                    is_error: checkFieldState('maxAttachmentsPerDocument', 'error'),
-                    is_success: checkFieldState('maxAttachmentsPerDocument', 'success'),
-                  })}
-                >
-                  <InputTextField
-                    reset={() => {
-                      resetForm();
-                      resetUpdateFieldInfo();
-                    }}
-                    {...register('maxAttachmentsPerDocument', {
-                      required: 'Max Attachments Per Document is required',
-                      pattern: {
-                        value: /^[0-9]+$/,
-                        message: 'Max Attachments Per Document must be a positive integer',
-                      },
-                      onChange: async () => {
-                        await trigger('maxAttachmentsPerDocument');
-                      },
-                    })}
-                    onChange={(e) => {
-                      setUpdateFieldInfo((info) => ({ ...info, target: 'maxAttachmentsPerDocument' }));
-                      maxAttachmentsPerDocument.onChange(e.target.value);
-                    }}
-                    id="maxAttachmentsPerDocument"
-                    label="Max Attachments Per Document"
-                    blindLabel={true}
-                    fieldUtil={true}
-                    placeholder="0"
-                    state={
-                      checkFieldState('maxAttachmentsPerDocument', 'success')
-                        ? 'success'
-                        : checkFieldState('maxAttachmentsPerDocument', 'error')
-                          ? 'error'
-                          : undefined
-                    }
-                    helperText={
-                      updateFieldInfo.target === 'maxAttachmentsPerDocument' && updateFieldInfo.state !== null
-                        ? updateFieldInfo.message
-                        : undefined
-                    }
-                    onSuccessEnd={resetUpdateFieldInfo}
-                  />
-                </div>
-              </dd>
-
-              <dt className="sub_title">Max Subscribers Per Document</dt>
-              <dd className="sub_desc">
-                <p className="guide">
-                  Limit the number of clients that can subscribe (watch for changes) to a single document simultaneously.
-                  When exceeded, the SDK auto-retries subscription once per second. Set to 0 for unlimited. Use this to
-                  prevent resource exhaustion from too many concurrent watchers.{' '}
-                  <a
-                    href="https://yorkie.dev/docs/advanced/resources#maxsubscribersperdocument"
-                    className="page_link icon_link"
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    Learn more about Max Subscribers Per Document.
-                  </a>
-                </p>
-                <div
-                  className={classNames('input_field_box', {
-                    is_error: checkFieldState('maxSubscribersPerDocument', 'error'),
-                    is_success: checkFieldState('maxSubscribersPerDocument', 'success'),
-                  })}
-                >
-                  <InputTextField
-                    reset={() => {
-                      resetForm();
-                      resetUpdateFieldInfo();
-                    }}
-                    {...register('maxSubscribersPerDocument', {
-                      required: 'Max Subscribers Per Document is required',
-                      pattern: {
-                        value: /^[0-9]+$/,
-                        message: 'Max Subscribers Per Document must be a positive integer',
-                      },
-                      onChange: async () => {
-                        await trigger('maxSubscribersPerDocument');
-                      },
-                    })}
-                    onChange={(e) => {
-                      setUpdateFieldInfo((info) => ({ ...info, target: 'maxSubscribersPerDocument' }));
-                      maxSubscribersPerDocument.onChange(e.target.value);
-                    }}
-                    id="maxSubscribersPerDocument"
-                    label="Max Subscribers Per Document"
-                    blindLabel={true}
-                    fieldUtil={true}
-                    placeholder="0"
-                    state={
-                      checkFieldState('maxSubscribersPerDocument', 'success')
-                        ? 'success'
-                        : checkFieldState('maxSubscribersPerDocument', 'error')
-                          ? 'error'
-                          : undefined
-                    }
-                    helperText={
-                      updateFieldInfo.target === 'maxSubscribersPerDocument' && updateFieldInfo.state !== null
-                        ? updateFieldInfo.message
-                        : undefined
-                    }
-                    onSuccessEnd={resetUpdateFieldInfo}
-                  />
-                </div>
-              </dd>
-              <dt className="sub_title">Max Size Per Document</dt>
-              <dd className="sub_desc">
-                <p className="guide">
-                  Set the maximum document size in bytes. Document size includes both content and CRDT metadata for
-                  synchronization, so the actual size may exceed visible content. Local updates exceeding this limit are
-                  rejected; remote updates are always applied to ensure consistency. Default: 10 MiB.{' '}
-                  <a
-                    href="https://yorkie.dev/docs/advanced/resources#maxsizeperdocument"
-                    className="page_link icon_link"
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    Learn more about Max Size Per Document.
-                  </a>
-                </p>
-                <div
-                  className={classNames('input_field_box', {
-                    is_error: checkFieldState('maxSizePerDocument', 'error'),
-                    is_success: checkFieldState('maxSizePerDocument', 'success'),
-                  })}
-                >
-                  <InputTextField
-                    reset={() => {
-                      resetForm();
-                      resetUpdateFieldInfo();
-                    }}
-                    {...register('maxSizePerDocument', {
-                      required: 'Max Size Per Document is required',
-                      pattern: {
-                        value: /^[0-9]+$/,
-                        message: 'Max Size Per Document must be a positive integer',
-                      },
-                      onChange: async () => {
-                        await trigger('maxSizePerDocument');
-                      },
-                    })}
-                    onChange={(e) => {
-                      setUpdateFieldInfo((info) => ({ ...info, target: 'maxSizePerDocument' }));
-                      maxSizePerDocument.onChange(e.target.value);
-                    }}
-                    id="maxSizePerDocument"
-                    label="Max Size Per Document"
-                    blindLabel={true}
-                    fieldUtil={true}
-                    placeholder="0"
-                    state={
-                      checkFieldState('maxSizePerDocument', 'success')
-                        ? 'success'
-                        : checkFieldState('maxSizePerDocument', 'error')
-                          ? 'error'
-                          : undefined
-                    }
-                    helperText={
-                      updateFieldInfo.target === 'maxSizePerDocument' && updateFieldInfo.state !== null
-                        ? updateFieldInfo.message
-                        : undefined
-                    }
-                    onSuccessEnd={resetUpdateFieldInfo}
-                  />
-                </div>
-              </dd>
-              <dt className="sub_title">Auto Revision Enabled</dt>
-              <dd className="sub_desc">
-                <p className="guide">
-                  Enable automatic revision creation during snapshot creation. Revisions allow you to browse document
-                  history and restore previous versions. When enabled, a revision is saved each time a snapshot is
-                  created (based on Snapshot Interval). Default: enabled.{' '}
-                  <a
-                    href="https://yorkie.dev/docs/advanced/resources#autorevisionenabled"
-                    className="page_link icon_link"
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    Learn more about Auto Revision.
-                  </a>
-                </p>
-                <div
-                  className={classNames('input_field_box', {
-                    is_error: checkFieldState('autoRevisionEnabled', 'error'),
-                    is_success: checkFieldState('autoRevisionEnabled', 'success'),
-                  })}
-                >
-                  <InputToggle
-                    id="autoRevisionEnabled"
-                    label=""
-                    checked={autoRevisionEnabled.value}
-                    onChange={(e) => {
-                      autoRevisionEnabled.onChange(e.target.checked);
-                      setUpdateFieldInfo((info) => ({ ...info, target: 'autoRevisionEnabled' }));
-                      onSubmit({ autoRevisionEnabled: e.target.checked });
-                    }}
-                  />
-                  {updateFieldInfo.target === 'autoRevisionEnabled' && updateFieldInfo.state !== null && (
-                    <InputHelperText
-                      state={updateFieldInfo.state}
-                      message={updateFieldInfo.message}
+                      }
                       onSuccessEnd={resetUpdateFieldInfo}
                     />
-                  )}
-                </div>
-              </dd>
-              <dt className="sub_title">Remove On Detach</dt>
-              <dd className="sub_desc">
-                <p className="guide">
-                  Automatically delete documents when the last client detaches. Useful for temporary collaboration
-                  sessions where you don&apos;t need to persist documents after editing ends. Warning: Once enabled,
-                  documents are permanently deleted when all clients detach and cannot be recovered.{' '}
-                  <a
-                    href="https://yorkie.dev/docs/advanced/resources#removeondetach"
-                    className="page_link icon_link"
-                    target="_blank"
-                    rel="noreferrer"
+                  </div>
+                </dd>
+                <dt className="sub_title">Members</dt>
+                <dd className="sub_desc">
+                  <p className="guide">
+                    Manage project members and their roles. Members can collaborate on documents and access project
+                    resources based on their assigned roles.
+                  </p>
+                  <MembersList />
+                </dd>
+              </dl>
+            </div>
+            <div className="section setting_box webhook" id="webhooks">
+              <div className="setting_title">
+                <strong className="text">Webhooks</strong>
+              </div>
+              <dl className="sub_info">
+                <dt className="sub_title">Webhook URL</dt>
+                <dd className="sub_desc">
+                  <p className="guide">
+                    Set the webhook URL for event notifications. When enabled events occur (e.g., document content
+                    changes), Yorkie sends a POST request to this endpoint with event details. Use this for
+                    integrations, notifications, or syncing with external systems. Changes may take up to 10 minutes to
+                    take effect.{' '}
+                    <a
+                      href="https://yorkie.dev/docs/advanced/event-webhook"
+                      className="page_link icon_link"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      Learn more about Event Webhook.
+                    </a>
+                  </p>
+                  <div
+                    className={classNames('input_field_box', {
+                      is_error: checkFieldState('eventWebhookURL', 'error'),
+                      is_success: checkFieldState('eventWebhookURL', 'success'),
+                    })}
                   >
-                    Learn more about Remove On Detach.
-                  </a>
-                </p>
-                <div
-                  className={classNames('input_field_box', {
-                    is_error: checkFieldState('removeOnDetach', 'error'),
-                    is_success: checkFieldState('removeOnDetach', 'success'),
-                  })}
-                >
-                  <InputToggle
-                    id="removeOnDetach"
-                    label=""
-                    checked={removeOnDetach.value}
-                    onChange={(e) => {
-                      removeOnDetach.onChange(e.target.checked);
-                      setUpdateFieldInfo((info) => ({ ...info, target: 'removeOnDetach' }));
-                      onSubmit({ removeOnDetach: e.target.checked });
-                    }}
-                  />
-                  {updateFieldInfo.target === 'removeOnDetach' && updateFieldInfo.state !== null && (
-                    <InputHelperText
-                      state={updateFieldInfo.state}
-                      message={updateFieldInfo.message}
+                    <InputTextField
+                      reset={() => {
+                        resetForm();
+                        resetUpdateFieldInfo();
+                      }}
+                      {...register('eventWebhookURL')}
+                      onChange={(e) => {
+                        setUpdateFieldInfo((info) => ({ ...info, target: 'eventWebhookURL' }));
+                        eventWebhookURLField.onChange(e.target.value);
+                      }}
+                      id="eventWebhookURL"
+                      label="eventWebhookURL"
+                      blindLabel={true}
+                      placeholder="http://localhost:8080/event"
+                      fieldUtil={true}
+                      state={
+                        checkFieldState('eventWebhookURL', 'success')
+                          ? 'success'
+                          : checkFieldState('eventWebhookURL', 'error')
+                            ? 'error'
+                            : undefined
+                      }
+                      helperText={
+                        updateFieldInfo.target === 'eventWebhookURL' && updateFieldInfo.state !== null
+                          ? updateFieldInfo.message
+                          : undefined
+                      }
                       onSuccessEnd={resetUpdateFieldInfo}
                     />
-                  )}
-                </div>
-              </dd>
-            </dl>
-          </div>
+                  </div>
+                </dd>
+                <dt className="sub_title">Webhook Events</dt>
+                <dd className="sub_desc">
+                  <p className="guide">
+                    Select which events require webhook event. Only the selected events will be checked for event.
+                  </p>
+                  <div className="webhook_events">
+                    {EVENT_WEBHOOK_EVENTS.map((event) => {
+                      return (
+                        <div
+                          className={classNames('input_group', {
+                            is_error: checkFieldState(event, 'error'),
+                            is_success: checkFieldState(event, 'success'),
+                          })}
+                          key={event}
+                        >
+                          <InputToggle
+                            id={event}
+                            label={event}
+                            checked={webhookEventField.value.includes(event)}
+                            onChange={(e) => {
+                              let newWebhookEvents = [...project?.eventWebhookEvents!];
+                              if (e.target.checked) {
+                                newWebhookEvents = newWebhookEvents.includes(event)
+                                  ? newWebhookEvents
+                                  : [...newWebhookEvents, event];
+                              } else {
+                                newWebhookEvents = newWebhookEvents.filter((newEvent) => newEvent !== event);
+                              }
+                              webhookEventField.onChange(newWebhookEvents);
+                              setUpdateFieldInfo((info) => ({ ...info, target: event }));
+                              onSubmit({ eventWebhookEvents: newWebhookEvents });
+                            }}
+                          />
+                          {updateFieldInfo.target === event && updateFieldInfo.state !== null && (
+                            <InputHelperText
+                              state={updateFieldInfo.state}
+                              message={updateFieldInfo.message}
+                              onSuccessEnd={resetUpdateFieldInfo}
+                            />
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                </dd>
+              </dl>
+            </div>
+            <div className="section setting_box webhook" id="security">
+              <div className="setting_title">
+                <strong className="text">Security</strong>
+              </div>
+              <dl className="sub_info">
+                <dt className="sub_title">Allowed Origins</dt>
+                <dd className="sub_desc">
+                  <p className="guide">
+                    Configure CORS (Cross-Origin Resource Sharing) by specifying which origins can connect to the Yorkie
+                    server. Use the wildcard character * to allow all origins, or specify individual origins separated
+                    by commas. Changes to this setting may take up to 10 minutes to take effect.{' '}
+                    <a
+                      href="https://yorkie.dev/docs/advanced/security#allowed-origins"
+                      className="page_link icon_link"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      Learn more about Allowed Origins.
+                    </a>
+                  </p>
+                  <div className="input_field_box">
+                    <InputTextField
+                      reset={() => {
+                        resetForm();
+                        resetUpdateFieldInfo();
+                      }}
+                      {...register('allowedOrigins', {
+                        validate: (value: string) => {
+                          if (!value) return true;
+                          const origins = value.split(',').map((origin) => origin.trim());
+                          const validOriginPattern = /^(\*|https?:\/\/[a-zA-Z0-9\-._~:/?#\[\]@!$&'()*+,;=]+)$/;
+                          return (
+                            origins.every((origin) => validOriginPattern.test(origin)) ||
+                            'Invalid origin format. Use valid URLs or * separated by commas'
+                          );
+                        },
+                      })}
+                      onChange={(e) => {
+                        setUpdateFieldInfo((info) => ({ ...info, target: 'allowedOrigins' }));
+                        allowedOrigins.onChange(e);
+                      }}
+                      onBlur={(e) => {
+                        // Normalize input by removing whitespace around commas
+                        const normalizedValue = e.target.value
+                          .split(',')
+                          .map((origin) => origin.trim())
+                          .filter((origin) => origin)
+                          .join(',');
+                        e.target.value = normalizedValue;
+                        allowedOrigins.onBlur();
+                      }}
+                      id="allowedOrigins"
+                      label="allowedOrigins"
+                      blindLabel={true}
+                      fieldUtil={true}
+                      placeholder="*, http://localhost:3000"
+                      state={
+                        checkFieldState('allowedOrigins', 'success')
+                          ? 'success'
+                          : checkFieldState('allowedOrigins', 'error')
+                            ? 'error'
+                            : undefined
+                      }
+                      helperText={
+                        updateFieldInfo.target === 'allowedOrigins' && updateFieldInfo.state !== null
+                          ? updateFieldInfo.message
+                          : undefined
+                      }
+                      onSuccessEnd={resetUpdateFieldInfo}
+                    />
+                  </div>
+                </dd>
+                <dt className="sub_title">Auth Webhook URL</dt>
+                <dd className="sub_desc">
+                  <p className="guide">
+                    Set the webhook URL for client authorization. When configured, Yorkie validates each client request
+                    by calling this endpoint with the client&apos;s token and requested action. Your server can then
+                    allow or deny access based on your custom authorization logic. Changes may take up to 10 minutes to
+                    take effect.{' '}
+                    <a
+                      href="https://yorkie.dev/docs/advanced/security#auth-webhook"
+                      className="page_link icon_link"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      Learn more about Auth Webhook.
+                    </a>
+                  </p>
+                  <div
+                    className={classNames('input_field_box', {
+                      is_error: checkFieldState('authWebhookURL', 'error'),
+                      is_success: checkFieldState('authWebhookURL', 'success'),
+                    })}
+                  >
+                    <InputTextField
+                      reset={() => {
+                        resetForm();
+                        resetUpdateFieldInfo();
+                      }}
+                      {...register('authWebhookURL')}
+                      onChange={(e) => {
+                        setUpdateFieldInfo((info) => ({ ...info, target: 'authWebhookURL' }));
+                        authWebhookURLField.onChange(e.target.value);
+                      }}
+                      id="authWebhookURL"
+                      label="authWebhookURL"
+                      blindLabel={true}
+                      placeholder="http://localhost:8080/auth"
+                      fieldUtil={true}
+                      state={
+                        checkFieldState('authWebhookURL', 'success')
+                          ? 'success'
+                          : checkFieldState('authWebhookURL', 'error')
+                            ? 'error'
+                            : undefined
+                      }
+                      helperText={
+                        updateFieldInfo.target === 'authWebhookURL' && updateFieldInfo.state !== null
+                          ? updateFieldInfo.message
+                          : undefined
+                      }
+                      onSuccessEnd={resetUpdateFieldInfo}
+                    />
+                  </div>
+                </dd>
+                <dt className="sub_title">Auth Webhook Methods</dt>
+                <dd className="sub_desc">
+                  <p className="guide">
+                    Select which methods require webhook authorization. Only the selected methods will be checked for
+                    authorization.
+                  </p>
+                  <div className="webhook_methods">
+                    {AUTH_WEBHOOK_METHODS.map((method) => {
+                      return (
+                        <div
+                          className={classNames('input_group', {
+                            is_error: checkFieldState(method, 'error'),
+                            is_success: checkFieldState(method, 'success'),
+                          })}
+                          key={method}
+                        >
+                          <InputToggle
+                            id={method}
+                            label={method}
+                            checked={webhookMethodField.value.includes(method)}
+                            onChange={(e) => {
+                              let newWebhookMethods = [...project?.authWebhookMethods!];
+                              if (e.target.checked) {
+                                newWebhookMethods = newWebhookMethods.includes(method)
+                                  ? newWebhookMethods
+                                  : [...newWebhookMethods, method];
+                              } else {
+                                newWebhookMethods = newWebhookMethods.filter((newMethod) => newMethod !== method);
+                              }
+                              webhookMethodField.onChange(newWebhookMethods);
+                              setUpdateFieldInfo((info) => ({ ...info, target: method }));
+                              onSubmit({ authWebhookMethods: newWebhookMethods });
+                            }}
+                          />
+                          {updateFieldInfo.target === method && updateFieldInfo.state !== null && (
+                            <InputHelperText
+                              state={updateFieldInfo.state}
+                              message={updateFieldInfo.message}
+                              onSuccessEnd={resetUpdateFieldInfo}
+                            />
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                </dd>
+              </dl>
+            </div>
+            <div className="section setting_box" id="resources">
+              <div className="setting_title">
+                <strong className="text">Resources</strong>
+              </div>
+              <dl className="sub_info">
+                <dt className="sub_title">Client Deactivate Threshold</dt>
+                <dd className="sub_desc">
+                  <p className="guide">
+                    Set the duration after which inactive clients are automatically deactivated. This improves garbage
+                    collection efficiency by cleaning up stale client connections. Format: &quot;24h0m0s&quot; for 24
+                    hours, &quot;1h30m&quot; for 1 hour 30 minutes.{' '}
+                    <a
+                      href="https://yorkie.dev/docs/advanced/resources#clientdeactivatethreshold"
+                      className="page_link icon_link"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      Learn more about Client Deactivate Threshold.
+                    </a>
+                  </p>
+                  <div
+                    className={classNames('input_field_box', {
+                      is_error: checkFieldState('clientDeactivateThreshold', 'error'),
+                      is_success: checkFieldState('clientDeactivateThreshold', 'success'),
+                    })}
+                  >
+                    <InputTextField
+                      reset={() => {
+                        resetForm();
+                        resetUpdateFieldInfo();
+                      }}
+                      {...register('clientDeactivateThreshold', {
+                        required: 'Client Deactivate Threshold is required',
+                        pattern: {
+                          value: /^(\d{1,2}h\s?)?(\d{1,2}m\s?)?(\d{1,2}s)?$/,
+                          message:
+                            'Client Deactivate Threshold should be a signed sequence of decimal numbers, each with a unit suffix, such as "23h30m10s" or "2h45m"',
+                        },
+                        onChange: async () => {
+                          await trigger('clientDeactivateThreshold');
+                        },
+                      })}
+                      onChange={(e) => {
+                        setUpdateFieldInfo((info) => ({ ...info, target: 'clientDeactivateThreshold' }));
+                        clientDeactivateThreshold.onChange(e.target.value);
+                      }}
+                      id="clientDeactivateThreshold"
+                      label="clientDeactivateThreshold"
+                      blindLabel={true}
+                      fieldUtil={true}
+                      placeholder={'24h00m00s'}
+                      state={
+                        checkFieldState('clientDeactivateThreshold', 'success')
+                          ? 'success'
+                          : checkFieldState('clientDeactivateThreshold', 'error')
+                            ? 'error'
+                            : undefined
+                      }
+                      helperText={
+                        updateFieldInfo.target === 'clientDeactivateThreshold' && updateFieldInfo.state !== null
+                          ? updateFieldInfo.message
+                          : undefined
+                      }
+                      onSuccessEnd={resetUpdateFieldInfo}
+                    />
+                  </div>
+                </dd>
+                <dt className="sub_title">Channel Session TTL</dt>
+                <dd className="sub_desc">
+                  <p className="guide">
+                    Set how long a channel session is retained after a user leaves (1s–5m). Longer values keep users
+                    counted in presence longer after they disconnect, increasing the apparent live presence count.
+                    Format: &quot;15s&quot; for 15 seconds, &quot;1m30s&quot; for 1 minute 30 seconds.
+                  </p>
+                  <div
+                    className={classNames('input_field_box', {
+                      is_error: checkFieldState('channelSessionTtl', 'error'),
+                      is_success: checkFieldState('channelSessionTtl', 'success'),
+                    })}
+                  >
+                    <InputTextField
+                      reset={() => {
+                        resetForm();
+                        resetUpdateFieldInfo();
+                      }}
+                      {...register('channelSessionTtl', {
+                        required: 'Channel Session TTL is required',
+                        pattern: {
+                          value: /^(\d{1,2}h\s?)?(\d{1,2}m\s?)?(\d{1,2}s)?$/,
+                          message: 'Channel Session TTL should be a duration string such as "15s" or "1m30s" (1s–5m)',
+                        },
+                        onChange: async () => {
+                          await trigger('channelSessionTtl');
+                        },
+                      })}
+                      onChange={(e) => {
+                        setUpdateFieldInfo((info) => ({ ...info, target: 'channelSessionTtl' }));
+                        channelSessionTtl.onChange(e.target.value);
+                      }}
+                      id="channelSessionTtl"
+                      label="channelSessionTtl"
+                      blindLabel={true}
+                      fieldUtil={true}
+                      placeholder={'15s'}
+                      state={
+                        checkFieldState('channelSessionTtl', 'success')
+                          ? 'success'
+                          : checkFieldState('channelSessionTtl', 'error')
+                            ? 'error'
+                            : undefined
+                      }
+                      helperText={
+                        updateFieldInfo.target === 'channelSessionTtl' && updateFieldInfo.state !== null
+                          ? updateFieldInfo.message
+                          : undefined
+                      }
+                      onSuccessEnd={resetUpdateFieldInfo}
+                    />
+                  </div>
+                </dd>
+                <dt className="sub_title">Snapshot Threshold</dt>
+                <dd className="sub_desc">
+                  <p className="guide">
+                    Set the number of changes that triggers snapshot delivery instead of individual changes. When a
+                    client needs to sync more changes than this threshold, the server sends a complete document snapshot
+                    for better performance. Default: 500.{' '}
+                    <a
+                      href="https://yorkie.dev/docs/advanced/resources#snapshotthreshold"
+                      className="page_link icon_link"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      Learn more about Snapshot Threshold.
+                    </a>
+                  </p>
+                  <div
+                    className={classNames('input_field_box', {
+                      is_error: checkFieldState('snapshotThreshold', 'error'),
+                      is_success: checkFieldState('snapshotThreshold', 'success'),
+                    })}
+                  >
+                    <InputTextField
+                      reset={() => {
+                        resetForm();
+                        resetUpdateFieldInfo();
+                      }}
+                      {...register('snapshotThreshold', {
+                        required: 'Snapshot Threshold is required',
+                        pattern: {
+                          value: /^[0-9]+$/,
+                          message: 'Snapshot Threshold must be a positive integer',
+                        },
+                        onChange: async () => {
+                          await trigger('snapshotThreshold');
+                        },
+                      })}
+                      onChange={(e) => {
+                        setUpdateFieldInfo((info) => ({ ...info, target: 'snapshotThreshold' }));
+                        snapshotThreshold.onChange(e.target.value);
+                      }}
+                      id="snapshotThreshold"
+                      label="Snapshot Threshold"
+                      blindLabel={true}
+                      fieldUtil={true}
+                      placeholder="0"
+                      state={
+                        checkFieldState('snapshotThreshold', 'success')
+                          ? 'success'
+                          : checkFieldState('snapshotThreshold', 'error')
+                            ? 'error'
+                            : undefined
+                      }
+                      helperText={
+                        updateFieldInfo.target === 'snapshotThreshold' && updateFieldInfo.state !== null
+                          ? updateFieldInfo.message
+                          : undefined
+                      }
+                      onSuccessEnd={resetUpdateFieldInfo}
+                    />
+                  </div>
+                </dd>
+                <dt className="sub_title">Snapshot Interval</dt>
+                <dd className="sub_desc">
+                  <p className="guide">
+                    Set the interval (in number of changes) at which the server creates and stores document snapshots.
+                    Lower values create snapshots more frequently, using more storage but improving sync performance for
+                    reconnecting clients. Default: 500.{' '}
+                    <a
+                      href="https://yorkie.dev/docs/advanced/resources#snapshotinterval"
+                      className="page_link icon_link"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      Learn more about Snapshot Interval.
+                    </a>
+                  </p>
+                  <div
+                    className={classNames('input_field_box', {
+                      is_error: checkFieldState('snapshotInterval', 'error'),
+                      is_success: checkFieldState('snapshotInterval', 'success'),
+                    })}
+                  >
+                    <InputTextField
+                      reset={() => {
+                        resetForm();
+                        resetUpdateFieldInfo();
+                      }}
+                      {...register('snapshotInterval', {
+                        required: 'Snapshot Interval is required',
+                        pattern: {
+                          value: /^[0-9]+$/,
+                          message: 'Snapshot Interval must be a positive integer',
+                        },
+                        onChange: async () => {
+                          await trigger('snapshotInterval');
+                        },
+                      })}
+                      onChange={(e) => {
+                        setUpdateFieldInfo((info) => ({ ...info, target: 'snapshotInterval' }));
+                        snapshotInterval.onChange(e.target.value);
+                      }}
+                      id="snapshotInterval"
+                      label="Snapshot Interval"
+                      blindLabel={true}
+                      fieldUtil={true}
+                      placeholder="0"
+                      state={
+                        checkFieldState('snapshotInterval', 'success')
+                          ? 'success'
+                          : checkFieldState('snapshotInterval', 'error')
+                            ? 'error'
+                            : undefined
+                      }
+                      helperText={
+                        updateFieldInfo.target === 'snapshotInterval' && updateFieldInfo.state !== null
+                          ? updateFieldInfo.message
+                          : undefined
+                      }
+                      onSuccessEnd={resetUpdateFieldInfo}
+                    />
+                  </div>
+                </dd>
+
+                <dt className="sub_title">Max Attachments Per Document</dt>
+                <dd className="sub_desc">
+                  <p className="guide">
+                    Limit the number of clients that can attach to a single document simultaneously. When exceeded, new
+                    attachment requests are rejected and must be manually retried. Set to 0 for unlimited. Use this to
+                    control resource usage in high-traffic scenarios.{' '}
+                    <a
+                      href="https://yorkie.dev/docs/advanced/resources#maxattachmentsperdocument"
+                      className="page_link icon_link"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      Learn more about Max Attachments Per Document.
+                    </a>
+                  </p>
+                  <div
+                    className={classNames('input_field_box', {
+                      is_error: checkFieldState('maxAttachmentsPerDocument', 'error'),
+                      is_success: checkFieldState('maxAttachmentsPerDocument', 'success'),
+                    })}
+                  >
+                    <InputTextField
+                      reset={() => {
+                        resetForm();
+                        resetUpdateFieldInfo();
+                      }}
+                      {...register('maxAttachmentsPerDocument', {
+                        required: 'Max Attachments Per Document is required',
+                        pattern: {
+                          value: /^[0-9]+$/,
+                          message: 'Max Attachments Per Document must be a positive integer',
+                        },
+                        onChange: async () => {
+                          await trigger('maxAttachmentsPerDocument');
+                        },
+                      })}
+                      onChange={(e) => {
+                        setUpdateFieldInfo((info) => ({ ...info, target: 'maxAttachmentsPerDocument' }));
+                        maxAttachmentsPerDocument.onChange(e.target.value);
+                      }}
+                      id="maxAttachmentsPerDocument"
+                      label="Max Attachments Per Document"
+                      blindLabel={true}
+                      fieldUtil={true}
+                      placeholder="0"
+                      state={
+                        checkFieldState('maxAttachmentsPerDocument', 'success')
+                          ? 'success'
+                          : checkFieldState('maxAttachmentsPerDocument', 'error')
+                            ? 'error'
+                            : undefined
+                      }
+                      helperText={
+                        updateFieldInfo.target === 'maxAttachmentsPerDocument' && updateFieldInfo.state !== null
+                          ? updateFieldInfo.message
+                          : undefined
+                      }
+                      onSuccessEnd={resetUpdateFieldInfo}
+                    />
+                  </div>
+                </dd>
+
+                <dt className="sub_title">Max Subscribers Per Document</dt>
+                <dd className="sub_desc">
+                  <p className="guide">
+                    Limit the number of clients that can subscribe (watch for changes) to a single document
+                    simultaneously. When exceeded, the SDK auto-retries subscription once per second. Set to 0 for
+                    unlimited. Use this to prevent resource exhaustion from too many concurrent watchers.{' '}
+                    <a
+                      href="https://yorkie.dev/docs/advanced/resources#maxsubscribersperdocument"
+                      className="page_link icon_link"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      Learn more about Max Subscribers Per Document.
+                    </a>
+                  </p>
+                  <div
+                    className={classNames('input_field_box', {
+                      is_error: checkFieldState('maxSubscribersPerDocument', 'error'),
+                      is_success: checkFieldState('maxSubscribersPerDocument', 'success'),
+                    })}
+                  >
+                    <InputTextField
+                      reset={() => {
+                        resetForm();
+                        resetUpdateFieldInfo();
+                      }}
+                      {...register('maxSubscribersPerDocument', {
+                        required: 'Max Subscribers Per Document is required',
+                        pattern: {
+                          value: /^[0-9]+$/,
+                          message: 'Max Subscribers Per Document must be a positive integer',
+                        },
+                        onChange: async () => {
+                          await trigger('maxSubscribersPerDocument');
+                        },
+                      })}
+                      onChange={(e) => {
+                        setUpdateFieldInfo((info) => ({ ...info, target: 'maxSubscribersPerDocument' }));
+                        maxSubscribersPerDocument.onChange(e.target.value);
+                      }}
+                      id="maxSubscribersPerDocument"
+                      label="Max Subscribers Per Document"
+                      blindLabel={true}
+                      fieldUtil={true}
+                      placeholder="0"
+                      state={
+                        checkFieldState('maxSubscribersPerDocument', 'success')
+                          ? 'success'
+                          : checkFieldState('maxSubscribersPerDocument', 'error')
+                            ? 'error'
+                            : undefined
+                      }
+                      helperText={
+                        updateFieldInfo.target === 'maxSubscribersPerDocument' && updateFieldInfo.state !== null
+                          ? updateFieldInfo.message
+                          : undefined
+                      }
+                      onSuccessEnd={resetUpdateFieldInfo}
+                    />
+                  </div>
+                </dd>
+                <dt className="sub_title">Max Size Per Document</dt>
+                <dd className="sub_desc">
+                  <p className="guide">
+                    Set the maximum document size in bytes. Document size includes both content and CRDT metadata for
+                    synchronization, so the actual size may exceed visible content. Local updates exceeding this limit
+                    are rejected; remote updates are always applied to ensure consistency. Default: 10 MiB.{' '}
+                    <a
+                      href="https://yorkie.dev/docs/advanced/resources#maxsizeperdocument"
+                      className="page_link icon_link"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      Learn more about Max Size Per Document.
+                    </a>
+                  </p>
+                  <div
+                    className={classNames('input_field_box', {
+                      is_error: checkFieldState('maxSizePerDocument', 'error'),
+                      is_success: checkFieldState('maxSizePerDocument', 'success'),
+                    })}
+                  >
+                    <InputTextField
+                      reset={() => {
+                        resetForm();
+                        resetUpdateFieldInfo();
+                      }}
+                      {...register('maxSizePerDocument', {
+                        required: 'Max Size Per Document is required',
+                        pattern: {
+                          value: /^[0-9]+$/,
+                          message: 'Max Size Per Document must be a positive integer',
+                        },
+                        onChange: async () => {
+                          await trigger('maxSizePerDocument');
+                        },
+                      })}
+                      onChange={(e) => {
+                        setUpdateFieldInfo((info) => ({ ...info, target: 'maxSizePerDocument' }));
+                        maxSizePerDocument.onChange(e.target.value);
+                      }}
+                      id="maxSizePerDocument"
+                      label="Max Size Per Document"
+                      blindLabel={true}
+                      fieldUtil={true}
+                      placeholder="0"
+                      state={
+                        checkFieldState('maxSizePerDocument', 'success')
+                          ? 'success'
+                          : checkFieldState('maxSizePerDocument', 'error')
+                            ? 'error'
+                            : undefined
+                      }
+                      helperText={
+                        updateFieldInfo.target === 'maxSizePerDocument' && updateFieldInfo.state !== null
+                          ? updateFieldInfo.message
+                          : undefined
+                      }
+                      onSuccessEnd={resetUpdateFieldInfo}
+                    />
+                  </div>
+                </dd>
+                <dt className="sub_title">Auto Revision Enabled</dt>
+                <dd className="sub_desc">
+                  <p className="guide">
+                    Enable automatic revision creation during snapshot creation. Revisions allow you to browse document
+                    history and restore previous versions. When enabled, a revision is saved each time a snapshot is
+                    created (based on Snapshot Interval). Default: enabled.{' '}
+                    <a
+                      href="https://yorkie.dev/docs/advanced/resources#autorevisionenabled"
+                      className="page_link icon_link"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      Learn more about Auto Revision.
+                    </a>
+                  </p>
+                  <div
+                    className={classNames('input_field_box', {
+                      is_error: checkFieldState('autoRevisionEnabled', 'error'),
+                      is_success: checkFieldState('autoRevisionEnabled', 'success'),
+                    })}
+                  >
+                    <InputToggle
+                      id="autoRevisionEnabled"
+                      label=""
+                      checked={autoRevisionEnabled.value}
+                      onChange={(e) => {
+                        autoRevisionEnabled.onChange(e.target.checked);
+                        setUpdateFieldInfo((info) => ({ ...info, target: 'autoRevisionEnabled' }));
+                        onSubmit({ autoRevisionEnabled: e.target.checked });
+                      }}
+                    />
+                    {updateFieldInfo.target === 'autoRevisionEnabled' && updateFieldInfo.state !== null && (
+                      <InputHelperText
+                        state={updateFieldInfo.state}
+                        message={updateFieldInfo.message}
+                        onSuccessEnd={resetUpdateFieldInfo}
+                      />
+                    )}
+                  </div>
+                </dd>
+                <dt className="sub_title">Remove On Detach</dt>
+                <dd className="sub_desc">
+                  <p className="guide">
+                    Automatically delete documents when the last client detaches. Useful for temporary collaboration
+                    sessions where you don&apos;t need to persist documents after editing ends. Warning: Once enabled,
+                    documents are permanently deleted when all clients detach and cannot be recovered.{' '}
+                    <a
+                      href="https://yorkie.dev/docs/advanced/resources#removeondetach"
+                      className="page_link icon_link"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      Learn more about Remove On Detach.
+                    </a>
+                  </p>
+                  <div
+                    className={classNames('input_field_box', {
+                      is_error: checkFieldState('removeOnDetach', 'error'),
+                      is_success: checkFieldState('removeOnDetach', 'success'),
+                    })}
+                  >
+                    <InputToggle
+                      id="removeOnDetach"
+                      label=""
+                      checked={removeOnDetach.value}
+                      onChange={(e) => {
+                        removeOnDetach.onChange(e.target.checked);
+                        setUpdateFieldInfo((info) => ({ ...info, target: 'removeOnDetach' }));
+                        onSubmit({ removeOnDetach: e.target.checked });
+                      }}
+                    />
+                    {updateFieldInfo.target === 'removeOnDetach' && updateFieldInfo.state !== null && (
+                      <InputHelperText
+                        state={updateFieldInfo.state}
+                        message={updateFieldInfo.message}
+                        onSuccessEnd={resetUpdateFieldInfo}
+                      />
+                    )}
+                  </div>
+                </dd>
+              </dl>
+            </div>
+          </fieldset>
         </form>
       </div>
     </div>

--- a/src/features/projects/Settings.tsx
+++ b/src/features/projects/Settings.tsx
@@ -48,15 +48,10 @@ export function Settings() {
   const dispatch = useAppDispatch();
   const { project } = useAppSelector(selectProjectDetail);
   const { isSuccess, error } = useAppSelector(selectProjectUpdate);
-  // Project config is editable only by Owners and Admins. Members get a
-  // read-only view. The role is resolved from the members list (loaded by the
-  // <MembersList /> below); until it is known we default to read-only so that
-  // access never briefly opens up for a Member. The Admin API enforces the same
-  // rule, so this only gates the UI. See yorkie-team/yorkie feat/update-project-rbac.
+  // Only Owners and Admins can edit; unknown/other roles default to read-only until resolved.
   const currentMemberRole = useAppSelector(selectCurrentMemberRole);
   const canEditConfig = currentMemberRole === 'owner' || currentMemberRole === 'admin';
   const isReadOnly = !canEditConfig;
-  const isMember = currentMemberRole === 'member';
   const [updateFieldInfo, setUpdateFieldInfo] = useState<UpdateFieldInfo>({ target: null, state: null, message: '' });
   const {
     register,
@@ -178,9 +173,7 @@ export function Settings() {
 
   const onSubmit = useCallback(
     (fields: Partial<ProjectUpdateFields>) => {
-      // Guard against edits from users without permission (e.g. Members). The
-      // fields are disabled in the UI, but this keeps the client honest even if
-      // a control is triggered programmatically. The server enforces this too.
+      // UI already disables the fields; guard here too in case a control fires programmatically.
       if (!canEditConfig) return;
 
       const updateFields: Partial<ProjectUpdateFields> = {};
@@ -292,7 +285,7 @@ export function Settings() {
         ]}
       />
       <div className="box_right">
-        {isMember && (
+        {isReadOnly && (
           <div className="setting_readonly_notice" role="note">
             <Icon type="lockSmall" />
             <p>


### PR DESCRIPTION
**What this PR does / why we need it**:

Enforces role-based access control for **Update Project Config** in the dashboard
UI, per the permission matrix in #272. With Members now part of projects
(Owner / Admin / Member), only Owners and Admins may edit the project
configuration; Members get a read-only view.

**Changes**:

- Add a `selectCurrentMemberRole` selector to the members slice that resolves the
  signed-in user's normalized role from the members list.
- In `Settings`, derive `canEditConfig` (Owner/Admin) and render the entire
  project-config form read-only for Members by wrapping it in a disabled
  `fieldset`. `onSubmit` is also guarded as defense in depth.
- Show a read-only notice to Members explaining that only Owners and Admins can
  make changes.
- Default to read-only until the role is resolved so access never briefly opens
  up for a Member.

**Which issue(s) this PR fixes**:

Fixes the UI task of #272.

The Admin API enforces the same rule server-side (the check already exists in
`projects.UpdateProject`); the companion PR
yorkie-team/yorkie#1947 adds integration test coverage for it. This UI PR is
independent and can be reviewed/merged on its own.

**Special notes for your reviewer**:

Verified with `tsc --noEmit` (typecheck), `vitest run` (tests), production build
(`npm run build`), and Prettier. Role infra reused from the Members feature
(#269).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Restricted project settings editing to Owners and Admins.
  - Added a read-only view for all other roles, including a notice explaining that settings cannot be changed.
  - Disabled settings controls and blocked unauthorized submissions.
- **Style**
  - Added visual styling for read-only notices and disabled configuration fields.
  - Improved readability of values in disabled fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->